### PR TITLE
feat: Tailwind v4 + startup auto-load — build passes, 138 tests green

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,5 @@ yarn-error.log*
 .playwright-mcp/
 /.serena/
 /.claude/
-/docs/
+/docs/superpowers/plans/
 /implement/

--- a/docs/superpowers/specs/2026-06-05-startup-auto-load-design.md
+++ b/docs/superpowers/specs/2026-06-05-startup-auto-load-design.md
@@ -1,0 +1,154 @@
+# Startup Auto-Load Design
+
+**Goal:** On launch, if a library path was saved from a previous session and the file is still reachable, parse and load it automatically while the splash screen is showing. If the file is gone or unreadable, forget the path and show the import page.
+
+**Architecture:** A single new IPC call (`file-exists`) handles the reachability check. `useLibrary` owns the startup sequence and exposes a `startupComplete` boolean. `AppWithRouter` shows `<SplashScreen />` until that flag is true. No minimum delay — the splash lasts exactly as long as the startup check needs.
+
+**Tech Stack:** Electron IPC, React 18, Zustand, `fs.access` (Node.js)
+
+---
+
+## IPC layer (`src/main/main.ts` + `src/main/preload.ts`)
+
+### New handler: `file-exists`
+
+```typescript
+ipcMain.handle('file-exists', async (_, path: string) => {
+  try {
+    await fs.promises.access(path, fs.constants.R_OK);
+    return { accessible: true };
+  } catch {
+    return { accessible: false };
+  }
+});
+```
+
+### Preload (`src/main/preload.ts`)
+
+Add alongside existing entries:
+```typescript
+checkFileAccessible: (path: string) => ipcRenderer.invoke('file-exists', path),
+```
+
+### Type declaration (`src/renderer/types/index.ts`)
+
+Add to the `electronAPI` interface:
+```typescript
+checkFileAccessible: (path: string) => Promise<{ accessible: boolean }>;
+```
+
+---
+
+## `useLibrary` hook (`src/renderer/hooks/useLibrary.ts`)
+
+### New state
+
+```typescript
+const [startupComplete, setStartupComplete] = useState(false);
+```
+
+### Startup `useEffect` — replace existing
+
+Current behaviour: restores path from localStorage, tries (and silently fails) to deserialize library JSON.
+
+New behaviour:
+
+```typescript
+useEffect(() => {
+  const run = async () => {
+    const savedPath = localStorage.getItem('rekordboxLibraryPath');
+
+    if (!savedPath) {
+      setStartupComplete(true);
+      return;
+    }
+
+    const { accessible } = await window.electronAPI.checkFileAccessible(savedPath);
+
+    if (accessible) {
+      await loadLibrary(savedPath);   // sets libraryPath + libraryData on success
+    } else {
+      localStorage.removeItem('rekordboxLibraryPath');
+      // libraryPath and libraryData remain '' / null — import page shows
+    }
+
+    setStartupComplete(true);
+  };
+
+  run();
+}, []); // eslint-disable-line react-hooks/exhaustive-deps
+```
+
+`loadLibrary` already handles parse failure gracefully (clears path, shows error notification) — no additional error handling needed here.
+
+### Remove
+
+- The `useEffect` that tries to deserialize `rekordboxLibraryData` from localStorage (unreliable for real-sized libraries; auto-load replaces it)
+- The `useEffect` that serializes library data to `rekordboxLibraryData`
+- The `localStorage.removeItem('rekordboxLibraryData')` call in `clearStoredData`
+
+### Return value
+
+Add `startupComplete` to the hook's return object.
+
+---
+
+## `AppWithRouter.tsx`
+
+### Remove
+
+```typescript
+// Remove this entire block:
+const [showSplash, setShowSplash] = useState(true);
+
+useEffect(() => {
+  const timer = setTimeout(() => {
+    setShowSplash(false);
+  }, 2000);
+  return () => clearTimeout(timer);
+}, []);
+```
+
+### Replace with
+
+```typescript
+const { startupComplete, /* ...other exports */ } = useLibrary(showNotification);
+
+if (!startupComplete) {
+  return <SplashScreen />;
+}
+```
+
+`showSplash` state and the timer `useEffect` are fully deleted. `startupComplete` from `useLibrary` is the single source of truth.
+
+---
+
+## Error handling
+
+| Scenario | Behaviour |
+|---|---|
+| No saved path | `startupComplete = true` immediately, import page shown |
+| Path saved, file accessible | Splash shows while parsing; main UI when done |
+| Path saved, file not accessible | Path removed from localStorage, `startupComplete = true`, import page shown |
+| Path saved, file accessible but invalid XML | `loadLibrary` returns `{success: false}`, shows error notification, clears path, `startupComplete = true`, import page shown |
+| Path saved, parse throws unexpectedly | `loadLibrary` catch block fires, clears path, `startupComplete = true` |
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/main/main.ts` | Add `file-exists` IPC handler |
+| `src/main/preload.ts` | Add `checkFileAccessible` |
+| `src/renderer/types/index.ts` | Add `checkFileAccessible` to `electronAPI` interface |
+| `src/renderer/hooks/useLibrary.ts` | Startup sequence rewrite; remove localStorage data serialisation; expose `startupComplete` |
+| `src/renderer/AppWithRouter.tsx` | Replace hardcoded splash timer with `startupComplete` gate |
+
+---
+
+## Out of scope
+
+- Minimum splash delay (none — splash lasts exactly as long as the check needs)
+- Progress indication during parse (the existing splash is static; no progress bar)
+- Watching the file for changes after load

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "dependencies": {
     "@radix-ui/react-popover": "^1.1.15",
+    "@tailwindcss/vite": "^4.3.0",
     "@tanstack/react-router": "^1.170.11",
     "autoprefixer": "^10.5.0",
     "crypto-js": "^4.2.0",
@@ -95,7 +96,7 @@
     "react-dropzone": "^15.0.0",
     "react-hook-form": "^7.77.0",
     "recharts": "^3.8.1",
-    "tailwindcss": "^3.4.10",
+    "tailwindcss": "^4.3.0",
     "xml2js": "^0.6.2",
     "zustand": "^5.0.14"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0))
       '@tanstack/react-router':
         specifier: ^1.170.11
         version: 1.170.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -66,8 +69,8 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.7)(react@18.3.1)(redux@5.0.1)
       tailwindcss:
-        specifier: ^3.4.10
-        version: 3.4.19
+        specifier: ^4.3.0
+        version: 4.3.0
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
@@ -119,7 +122,7 @@ importers:
         version: 8.60.1(eslint@8.57.1)(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7))
+        version: 5.2.0(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0))
       '@vitest/ui':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -161,10 +164,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)
+        version: 8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.19)(@vitest/ui@4.1.8)(happy-dom@20.10.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7))
+        version: 4.1.8(@types/node@22.19.19)(@vitest/ui@4.1.8)(happy-dom@20.10.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0))
 
 packages:
 
@@ -173,10 +176,6 @@ packages:
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
-
-  '@alloc/quick-lru@5.2.0':
-    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
-    engines: {node: '>=10'}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -1019,6 +1018,96 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
+  '@tailwindcss/node@4.3.0':
+    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.0':
+    resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.0':
+    resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
   '@tanstack/history@1.162.0':
     resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
     engines: {node: '>=20.19'}
@@ -1377,13 +1466,6 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
-  any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
-
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-
   app-builder-bin@5.0.0-alpha.12:
     resolution: {integrity: sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==}
 
@@ -1393,9 +1475,6 @@ packages:
     peerDependencies:
       dmg-builder: 26.8.1
       electron-builder-squirrel-windows: 26.8.1
-
-  arg@5.0.2:
-    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1517,10 +1596,6 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
-
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -1534,10 +1609,6 @@ packages:
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
-
-  braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -1588,10 +1659,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camelcase-css@2.0.1:
-    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
-    engines: {node: '>= 6'}
-
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
@@ -1606,10 +1673,6 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -1659,10 +1722,6 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-
-  commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
 
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
@@ -1716,11 +1775,6 @@ packages:
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
-
-  cssesc@3.0.0:
-    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1857,14 +1911,8 @@ packages:
   dexie@4.4.3:
     resolution: {integrity: sha512-N+3IGQ3HPlyO2YAkntGAwitm42BpBGV86MttzUMiRzWLa4NGh0pltVRcUVF4ybL/OnXjCrr9k7SDPIKkFYP2Lg==}
 
-  didyoumean@1.2.2:
-    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
-
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
-
-  dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   dmg-builder@26.8.1:
     resolution: {integrity: sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==}
@@ -1961,6 +2009,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  enhanced-resolve@5.22.2:
+    resolution: {integrity: sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==}
+    engines: {node: '>=10.13.0'}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -2174,10 +2226,6 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
-
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -2216,10 +2264,6 @@ packages:
 
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
-
-  fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -2342,10 +2386,6 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
-
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -2504,10 +2544,6 @@ packages:
     resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
     engines: {node: '>= 0.4'}
 
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
@@ -2563,10 +2599,6 @@ packages:
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
-
-  is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
 
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
@@ -2677,10 +2709,6 @@ packages:
   jest-util@30.4.1:
     resolution: {integrity: sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jiti@1.21.7:
-    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
-    hasBin: true
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -2825,13 +2853,6 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  lilconfig@3.1.3:
-    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
-    engines: {node: '>=14'}
-
-  lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-
   link@2.1.2:
     resolution: {integrity: sha512-n+OitQgtITNBGiWmEMgMiXo/fkf3yeyLm2nXm87vO4DDpaYrx57AZs/PMDk25qJIv+l586V226B2mA1H/n9zvg==}
     hasBin: true
@@ -2891,14 +2912,6 @@ packages:
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
-
-  merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-
-  micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -2976,9 +2989,6 @@ packages:
     resolution: {integrity: sha512-9JcxgIlMPD1Mgzc2fTCaRtBR7GMQJ226gmh2iECzHwLRSrms1yPUxTivBbEiyUrshpmFnBv9baDkpkk9uxbfHw==}
     engines: {node: '>=18'}
 
-  mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
-
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3024,10 +3034,6 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
-  normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
   normalize-url@6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
@@ -3035,10 +3041,6 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -3142,21 +3144,9 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
-
-  pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
-
-  pirates@4.0.7:
-    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
-    engines: {node: '>= 6'}
 
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
@@ -3179,46 +3169,6 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
-
-  postcss-import@15.1.0:
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-
-  postcss-js@4.1.0:
-    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
-    engines: {node: ^12 || ^14 || >= 16}
-    peerDependencies:
-      postcss: ^8.4.21
-
-  postcss-load-config@6.0.1:
-    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-      postcss:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
-  postcss-nested@6.2.0:
-    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
-    engines: {node: '>=12.0'}
-    peerDependencies:
-      postcss: ^8.2.14
-
-  postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
-    engines: {node: '>=4'}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -3363,13 +3313,6 @@ packages:
     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
     hasBin: true
 
-  read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
-
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
-
   recharts@3.8.1:
     resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
     engines: {node: '>=18'}
@@ -3419,11 +3362,6 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-
-  resolve@1.22.12:
-    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
 
   resolve@2.0.0-next.7:
     resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
@@ -3699,11 +3637,6 @@ packages:
     resolution: {integrity: sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==}
     engines: {node: '>=16'}
 
-  sucrase@3.35.1:
-    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
-
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
@@ -3723,10 +3656,12 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  tailwindcss@3.4.19:
-    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
 
   tar@7.5.16:
     resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
@@ -3741,13 +3676,6 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-
-  thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
-
-  thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
@@ -3784,10 +3712,6 @@ packages:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
-  to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
-
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
@@ -3819,9 +3743,6 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-
-  ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
@@ -3932,9 +3853,6 @@ packages:
 
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
-
-  util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -4195,8 +4113,6 @@ snapshots:
   7zip-bin@5.2.0: {}
 
   '@adobe/css-tools@4.5.0': {}
-
-  '@alloc/quick-lru@5.2.0': {}
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -4967,6 +4883,74 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@tailwindcss/node@4.3.0':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.22.2
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.0
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.0':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-x64': 4.3.0
+      '@tailwindcss/oxide-freebsd-x64': 4.3.0
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
+
+  '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)
+
   '@tanstack/history@1.162.0': {}
 
   '@tanstack/react-router@1.170.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -5290,7 +5274,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@5.2.0(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7))':
+  '@vitejs/plugin-react@5.2.0(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -5298,7 +5282,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)
+      vite: 8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5311,13 +5295,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)
+      vite: 8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -5346,7 +5330,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@22.19.19)(@vitest/ui@4.1.8)(happy-dom@20.10.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7))
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/ui@4.1.8)(happy-dom@20.10.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0))
 
   '@vitest/utils@4.1.8':
     dependencies:
@@ -5392,13 +5376,6 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  any-promise@1.3.0: {}
-
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.2
-
   app-builder-bin@5.0.0-alpha.12: {}
 
   app-builder-lib@26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1):
@@ -5443,8 +5420,6 @@ snapshots:
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
-
-  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -5576,8 +5551,6 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  binary-extensions@2.3.0: {}
-
   boolean@3.2.0:
     optional: true
 
@@ -5593,10 +5566,6 @@ snapshots:
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
-
-  braces@3.0.3:
-    dependencies:
-      fill-range: 7.1.1
 
   browserslist@4.28.2:
     dependencies:
@@ -5679,8 +5648,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase-css@2.0.1: {}
-
   caniuse-lite@1.0.30001793: {}
 
   chai@6.2.2: {}
@@ -5691,18 +5658,6 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
-
-  chokidar@3.6.0:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
   chownr@3.0.0: {}
 
@@ -5750,8 +5705,6 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-
-  commander@4.1.1: {}
 
   commander@5.1.0: {}
 
@@ -5802,8 +5755,6 @@ snapshots:
       source-map-js: 1.2.1
 
   css.escape@1.5.1: {}
-
-  cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -5922,14 +5873,10 @@ snapshots:
 
   dexie@4.4.3: {}
 
-  didyoumean@1.2.2: {}
-
   dir-compare@4.2.0:
     dependencies:
       minimatch: 3.1.5
       p-limit: 3.1.0
-
-  dlv@1.1.3: {}
 
   dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1):
     dependencies:
@@ -6079,6 +6026,11 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  enhanced-resolve@5.22.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   entities@7.0.1: {}
 
@@ -6443,14 +6395,6 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-glob@3.3.3:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -6487,10 +6431,6 @@ snapshots:
   filelist@1.0.6:
     dependencies:
       minimatch: 5.1.9
-
-  fill-range@7.1.1:
-    dependencies:
-      to-regex-range: 5.0.1
 
   find-up@5.0.0:
     dependencies:
@@ -6624,10 +6564,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
-
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
 
   glob-parent@6.0.2:
     dependencies:
@@ -6815,10 +6751,6 @@ snapshots:
     dependencies:
       has-bigints: 1.1.0
 
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
-
   is-boolean-object@1.2.2:
     dependencies:
       call-bound: 1.0.4
@@ -6871,8 +6803,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
-
-  is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
 
@@ -6993,8 +6923,6 @@ snapshots:
       ci-info: 4.4.0
       graceful-fs: 4.2.11
       picomatch: 4.0.4
-
-  jiti@1.21.7: {}
 
   jiti@2.7.0: {}
 
@@ -7130,10 +7058,6 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  lilconfig@3.1.3: {}
-
-  lines-and-columns@1.2.4: {}
-
   link@2.1.2: {}
 
   locate-path@6.0.0:
@@ -7180,13 +7104,6 @@ snapshots:
   mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
-
-  merge2@1.4.1: {}
-
-  micromatch@4.0.8:
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -7256,12 +7173,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mz@2.7.0:
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
-
   nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
@@ -7309,13 +7220,9 @@ snapshots:
     dependencies:
       abbrev: 4.0.0
 
-  normalize-path@3.0.0: {}
-
   normalize-url@6.1.0: {}
 
   object-assign@4.1.1: {}
-
-  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -7421,13 +7328,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.2: {}
-
   picomatch@4.0.4: {}
-
-  pify@2.3.0: {}
-
-  pirates@4.0.7: {}
 
   playwright-core@1.60.0: {}
 
@@ -7451,35 +7352,6 @@ snapshots:
     optional: true
 
   possible-typed-array-names@1.1.0: {}
-
-  postcss-import@15.1.0(postcss@8.5.15):
-    dependencies:
-      postcss: 8.5.15
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.12
-
-  postcss-js@4.1.0(postcss@8.5.15):
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.5.15
-
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15):
-    dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      jiti: 1.21.7
-      postcss: 8.5.15
-
-  postcss-nested@6.2.0(postcss@8.5.15):
-    dependencies:
-      postcss: 8.5.15
-      postcss-selector-parser: 6.1.2
-
-  postcss-selector-parser@6.1.2:
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
 
@@ -7618,14 +7490,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  read-cache@1.0.0:
-    dependencies:
-      pify: 2.3.0
-
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.2
-
   recharts@3.8.1(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.7)(react@18.3.1)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@18.3.30)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
@@ -7690,13 +7554,6 @@ snapshots:
   resolve-alpn@1.2.1: {}
 
   resolve-from@4.0.0: {}
-
-  resolve@1.22.12:
-    dependencies:
-      es-errors: 1.3.0
-      is-core-module: 2.16.2
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
 
   resolve@2.0.0-next.7:
     dependencies:
@@ -8030,16 +7887,6 @@ snapshots:
       '@tokenizer/token': 0.3.0
       peek-readable: 5.4.2
 
-  sucrase@3.35.1:
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      commander: 4.1.1
-      lines-and-columns: 1.2.4
-      mz: 2.7.0
-      pirates: 4.0.7
-      tinyglobby: 0.2.17
-      ts-interface-checker: 0.1.13
-
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3
@@ -8056,33 +7903,9 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tailwindcss@3.4.19:
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.15
-      postcss-import: 15.1.0(postcss@8.5.15)
-      postcss-js: 4.1.0(postcss@8.5.15)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)
-      postcss-nested: 6.2.0(postcss@8.5.15)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.12
-      sucrase: 3.35.1
-    transitivePeerDependencies:
-      - tsx
-      - yaml
+  tailwindcss@4.3.0: {}
+
+  tapable@2.3.3: {}
 
   tar@7.5.16:
     dependencies:
@@ -8103,14 +7926,6 @@ snapshots:
       rimraf: 2.6.3
 
   text-table@0.2.0: {}
-
-  thenify-all@1.6.0:
-    dependencies:
-      thenify: 3.3.1
-
-  thenify@3.3.1:
-    dependencies:
-      any-promise: 1.3.0
 
   tiny-async-pool@1.3.0:
     dependencies:
@@ -8141,10 +7956,6 @@ snapshots:
 
   tmp@0.2.7: {}
 
-  to-regex-range@5.0.1:
-    dependencies:
-      is-number: 7.0.0
-
   token-types@6.1.2:
     dependencies:
       '@borewit/text-codec': 0.2.2
@@ -8172,8 +7983,6 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
-
-  ts-interface-checker@0.1.13: {}
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -8285,8 +8094,6 @@ snapshots:
 
   utf8-byte-length@1.0.5: {}
 
-  util-deprecate@1.0.2: {}
-
   verror@1.10.1:
     dependencies:
       assert-plus: 1.0.0
@@ -8311,7 +8118,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7):
+  vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -8322,12 +8129,12 @@ snapshots:
       '@types/node': 22.19.19
       esbuild: 0.27.7
       fsevents: 2.3.3
-      jiti: 1.21.7
+      jiti: 2.7.0
 
-  vitest@4.1.8(@types/node@22.19.19)(@vitest/ui@4.1.8)(happy-dom@20.10.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)):
+  vitest@4.1.8(@types/node@22.19.19)(@vitest/ui@4.1.8)(happy-dom@20.10.1)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -8344,7 +8151,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)
+      vite: 8.0.16(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.19

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -292,6 +292,17 @@ app.on('activate', () => {
   }
 });
 
+// File reachability check — used by startup auto-load
+ipcMain.handle('file-exists', async (_, path: string) => {
+  const fs = require('fs');
+  try {
+    await fs.promises.access(path, fs.constants.R_OK);
+    return { accessible: true };
+  } catch {
+    return { accessible: false };
+  }
+});
+
 // IPC Handlers for Feature 1: Duplicate Detection
 
 ipcMain.handle('select-rekordbox-xml', async () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -4,6 +4,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 // the ipcRenderer without exposing the entire object
 contextBridge.exposeInMainWorld('electronAPI', {
   selectRekordboxXML: () => ipcRenderer.invoke('select-rekordbox-xml'),
+  checkFileAccessible: (path: string) => ipcRenderer.invoke('file-exists', path),
   selectFolder: () => ipcRenderer.invoke('select-folder'),
   parseRekordboxLibrary: (xmlPath: string) =>
     ipcRenderer.invoke('parse-rekordbox-library', xmlPath),

--- a/src/renderer/AppWithRouter.tsx
+++ b/src/renderer/AppWithRouter.tsx
@@ -34,7 +34,6 @@ const pathToTab: Record<string, TabType> = {
 };
 
 const AppWithRouter: React.FC = () => {
-  const [showSplash, setShowSplash] = useState(true);
   const [showAbout, setShowAbout] = useState(false);
   const [showTutorial, setShowTutorial] = useState(false);
   const location = useLocation();
@@ -48,6 +47,7 @@ const AppWithRouter: React.FC = () => {
     libraryPath,
     libraryData,
     isLoading,
+    startupComplete,
     selectLibrary,
     loadLibrary,
     clearStoredData,
@@ -60,14 +60,6 @@ const AppWithRouter: React.FC = () => {
     // duplicateResults, relocationResults, settings // Unused for now
   } = useRouteData(location.pathname, libraryPath);
 
-  // Hide splash screen after initial load
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setShowSplash(false);
-    }, 2000);
-
-    return () => clearTimeout(timer);
-  }, []);
 
   // Set up menu event listeners
   useEffect(() => {
@@ -95,8 +87,7 @@ const AppWithRouter: React.FC = () => {
     }
   }, []);
 
-  // Show splash screen during initial load
-  if (showSplash) {
+  if (!startupComplete) {
     return <SplashScreen />;
   }
 

--- a/src/renderer/hooks/useLibrary.ts
+++ b/src/renderer/hooks/useLibrary.ts
@@ -58,15 +58,20 @@ export const useLibrary = (showNotification: (type: NotificationType, message: s
         return;
       }
 
-      const { accessible } = await window.electronAPI.checkFileAccessible(savedPath);
+      try {
+        const { accessible } = await window.electronAPI.checkFileAccessible(savedPath);
 
-      if (accessible) {
-        await loadLibrary(savedPath);
-      } else {
+        if (accessible) {
+          await loadLibrary(savedPath);
+        } else {
+          localStorage.removeItem('rekordboxLibraryPath');
+        }
+      } catch (err) {
+        console.error('Startup auto-load failed:', err);
         localStorage.removeItem('rekordboxLibraryPath');
+      } finally {
+        setStartupComplete(true);
       }
-
-      setStartupComplete(true);
     };
 
     run();

--- a/src/renderer/hooks/useLibrary.ts
+++ b/src/renderer/hooks/useLibrary.ts
@@ -5,13 +5,12 @@ export const useLibrary = (showNotification: (type: NotificationType, message: s
   const [libraryPath, setLibraryPath] = useState<string>('');
   const [libraryData, setLibraryData] = useState<LibraryData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [startupComplete, setStartupComplete] = useState(false);
 
   const loadLibrary = useCallback(async (path: string) => {
     setIsLoading(true);
     try {
-      // Clear previous library data when loading new library
       setLibraryData(null);
-      // Set the new library path immediately
       setLibraryPath(path);
 
       const result = await window.electronAPI.parseRekordboxLibrary(path);
@@ -20,12 +19,10 @@ export const useLibrary = (showNotification: (type: NotificationType, message: s
         showNotification('success', `Loaded ${result.data.tracks.size} tracks from library`);
       } else {
         showNotification('error', result.error || 'Failed to parse library');
-        // Reset path if loading failed
         setLibraryPath('');
       }
-    } catch (error) {
+    } catch {
       showNotification('error', 'Failed to load library');
-      // Reset path if loading failed
       setLibraryPath('');
     } finally {
       setIsLoading(false);
@@ -38,60 +35,44 @@ export const useLibrary = (showNotification: (type: NotificationType, message: s
       if (path) {
         await loadLibrary(path);
       }
-    } catch (error) {
+    } catch {
       showNotification('error', 'Failed to select library file');
     }
   }, [loadLibrary, showNotification]);
 
   const clearStoredData = useCallback(() => {
     localStorage.removeItem('rekordboxLibraryPath');
-    localStorage.removeItem('rekordboxLibraryData');
     setLibraryPath('');
     setLibraryData(null);
     showNotification('info', 'Library data cleared');
   }, [showNotification]);
 
-  // Load persisted library data on mount
+  // Startup: auto-load last library if the file is still reachable.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    const savedLibraryPath = localStorage.getItem('rekordboxLibraryPath');
-    const savedLibraryData = localStorage.getItem('rekordboxLibraryData');
+    const run = async () => {
+      const savedPath = localStorage.getItem('rekordboxLibraryPath');
 
-    if (savedLibraryPath) {
-      setLibraryPath(savedLibraryPath);
-    }
-
-    if (savedLibraryData) {
-      try {
-        const parsedData = JSON.parse(savedLibraryData);
-        // Convert tracks array back to Map
-        if (parsedData && parsedData.tracks && Array.isArray(parsedData.tracks)) {
-          parsedData.tracks = new Map(parsedData.tracks);
-          setLibraryData(parsedData);
-        }
-      } catch (error) {
-        console.warn('Failed to load saved library data:', error);
-        localStorage.removeItem('rekordboxLibraryData');
+      if (!savedPath) {
+        setStartupComplete(true);
+        return;
       }
-    }
-  }, []);
 
-  // Save library data whenever it changes
-  useEffect(() => {
-    if (libraryData) {
-      try {
-        // Convert Map to array for JSON serialization
-        const dataToSave = {
-          ...libraryData,
-          tracks: Array.from(libraryData.tracks.entries())
-        };
-        localStorage.setItem('rekordboxLibraryData', JSON.stringify(dataToSave));
-      } catch (error) {
-        console.warn('Failed to save library data:', error);
+      const { accessible } = await window.electronAPI.checkFileAccessible(savedPath);
+
+      if (accessible) {
+        await loadLibrary(savedPath);
+      } else {
+        localStorage.removeItem('rekordboxLibraryPath');
       }
-    }
-  }, [libraryData]);
 
-  // Save library path whenever it changes
+      setStartupComplete(true);
+    };
+
+    run();
+  }, []); // intentionally empty — runs once on mount only
+
+  // Persist library path whenever it changes
   useEffect(() => {
     if (libraryPath) {
       localStorage.setItem('rekordboxLibraryPath', libraryPath);
@@ -102,9 +83,10 @@ export const useLibrary = (showNotification: (type: NotificationType, message: s
     libraryPath,
     libraryData,
     isLoading,
+    startupComplete,
     selectLibrary,
     loadLibrary,
     clearStoredData,
-    setLibraryData
+    setLibraryData,
   };
 };

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -2,6 +2,73 @@
 
 @import "tailwindcss";
 
+@theme {
+  /* TE colours */
+  --color-te-orange: #FF6B35;
+  --color-te-black: #0A0A0A;
+  --color-te-cream: #FAF6F2;
+  --color-te-yellow: #FFD93D;
+
+  --color-te-grey-50:  #FAFAFA;
+  --color-te-grey-100: #F5F5F5;
+  --color-te-grey-200: #E8E8E8;
+  --color-te-grey-300: #D1D1D1;
+  --color-te-grey-400: #A8A8A8;
+  --color-te-grey-500: #7A7A7A;
+  --color-te-grey-600: #4A4A4A;
+  --color-te-grey-700: #2D2D2D;
+  --color-te-grey-800: #1A1A1A;
+  --color-te-grey-900: #0F0F0F;
+
+  --color-te-red-50:  #FFF5F5;
+  --color-te-red-100: #FED7D7;
+  --color-te-red-200: #FEB2B2;
+  --color-te-red-500: #E53E3E;
+  --color-te-red-600: #C53030;
+
+  --color-te-green-50:  #F0FFF4;
+  --color-te-green-100: #C6F6D5;
+  --color-te-green-200: #9AE6B4;
+  --color-te-green-500: #38A169;
+  --color-te-green-600: #2F855A;
+
+  --color-te-amber-50:  #FFFBEB;
+  --color-te-amber-100: #FEF3C7;
+  --color-te-amber-200: #FDE68A;
+  --color-te-amber-500: #F59E0B;
+  --color-te-amber-600: #D97706;
+
+  --color-rekordbox-purple: #A855F7;
+  --color-rekordbox-dark:   #18181B;
+  --color-rekordbox-gray:   #27272A;
+  --color-rekordbox-light:  #F4F4F5;
+
+  /* TE fonts */
+  --font-te-display: 'Orbitron', 'Space Mono', 'JetBrains Mono', 'SF Mono', 'Monaco', 'Consolas', monospace;
+  --font-te-mono:    'Space Mono', 'JetBrains Mono', 'SF Mono', 'Monaco', 'Consolas', monospace;
+  --font-te-sans:    'Space Mono', 'Inter', system-ui, -apple-system, sans-serif;
+
+  /* TE letter spacing */
+  --tracking-te-display: 0.1em;
+  --tracking-te-mono:    0.025em;
+  --tracking-te-wide:    0.15em;
+
+  /* TE border radius */
+  --radius-te:    4px;
+  --radius-te-lg: 8px;
+
+  /* TE spacing */
+  --spacing-te-xs: 2px;
+  --spacing-te-sm: 4px;
+  --spacing-te-md: 8px;
+  --spacing-te-lg: 16px;
+  --spacing-te-xl: 24px;
+
+  /* TE animations */
+  --animate-pulse-slow: pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  --animate-te-glow:    glow 2s ease-in-out infinite alternate;
+}
+
 @layer base {
   html, body {
     @apply bg-te-grey-100 text-te-grey-800 font-te-mono;

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1,8 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700;900&family=Space+Mono:wght@400;700&display=swap');
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 @layer base {
   html, body {

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -173,6 +173,7 @@ declare global {
   interface Window {
     electronAPI: {
       selectRekordboxXML: () => Promise<string | null>;
+      checkFileAccessible: (path: string) => Promise<{ accessible: boolean }>;
       selectFolder: () => Promise<string | null>;
       parseRekordboxLibrary: (xmlPath: string) => Promise<any>;
       findDuplicates: (options: any) => Promise<any>;

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -80,6 +80,7 @@ export const loadFixture = (filename: string): string => {
 Object.defineProperty(window, 'electronAPI', {
   value: {
     selectRekordboxXML: vi.fn(),
+    checkFileAccessible: vi.fn(),
     selectFolder: vi.fn(),
     parseRekordboxLibrary: vi.fn(),
     findDuplicates: vi.fn(),

--- a/tests/unit/startup-auto-load.test.ts
+++ b/tests/unit/startup-auto-load.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useLibrary } from '../../src/renderer/hooks/useLibrary';
+
+describe('useLibrary startup auto-load', () => {
+  const mockShowNotification = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('sets startupComplete=true immediately when no saved path', async () => {
+    localStorage.removeItem('rekordboxLibraryPath');
+
+    const { result } = renderHook(() => useLibrary(mockShowNotification));
+
+    await waitFor(() => expect(result.current.startupComplete).toBe(true));
+    expect(result.current.libraryPath).toBe('');
+    expect(result.current.libraryData).toBeNull();
+    expect(window.electronAPI.checkFileAccessible).not.toHaveBeenCalled();
+  });
+
+  it('auto-loads library when saved path is accessible', async () => {
+    localStorage.setItem('rekordboxLibraryPath', '/path/to/library.xml');
+    window.electronAPI.checkFileAccessible.mockResolvedValue({ accessible: true });
+    window.electronAPI.parseRekordboxLibrary.mockResolvedValue({
+      success: true,
+      data: { libraryPath: '/path/to/library.xml', tracks: new Map(), playlists: [] },
+    });
+
+    const { result } = renderHook(() => useLibrary(mockShowNotification));
+
+    await waitFor(() => expect(result.current.startupComplete).toBe(true));
+    expect(window.electronAPI.checkFileAccessible).toHaveBeenCalledWith('/path/to/library.xml');
+    expect(window.electronAPI.parseRekordboxLibrary).toHaveBeenCalledWith('/path/to/library.xml');
+    expect(result.current.libraryPath).toBe('/path/to/library.xml');
+    expect(result.current.libraryData).not.toBeNull();
+  });
+
+  it('clears saved path and shows import page when file is not accessible', async () => {
+    localStorage.setItem('rekordboxLibraryPath', '/missing/library.xml');
+    window.electronAPI.checkFileAccessible.mockResolvedValue({ accessible: false });
+
+    const { result } = renderHook(() => useLibrary(mockShowNotification));
+
+    await waitFor(() => expect(result.current.startupComplete).toBe(true));
+    expect(window.electronAPI.parseRekordboxLibrary).not.toHaveBeenCalled();
+    expect(result.current.libraryPath).toBe('');
+    expect(result.current.libraryData).toBeNull();
+    expect(localStorage.getItem('rekordboxLibraryPath')).toBeNull();
+  });
+
+  it('clears path when file is accessible but XML parse fails', async () => {
+    localStorage.setItem('rekordboxLibraryPath', '/corrupt/library.xml');
+    window.electronAPI.checkFileAccessible.mockResolvedValue({ accessible: true });
+    window.electronAPI.parseRekordboxLibrary.mockResolvedValue({
+      success: false,
+      error: 'Not a valid Rekordbox XML file',
+    });
+
+    const { result } = renderHook(() => useLibrary(mockShowNotification));
+
+    await waitFor(() => expect(result.current.startupComplete).toBe(true));
+    expect(result.current.libraryPath).toBe('');
+    expect(result.current.libraryData).toBeNull();
+    expect(mockShowNotification).toHaveBeenCalledWith('error', expect.any(String));
+  });
+});

--- a/tests/unit/startup-auto-load.test.ts
+++ b/tests/unit/startup-auto-load.test.ts
@@ -66,4 +66,16 @@ describe('useLibrary startup auto-load', () => {
     expect(result.current.libraryData).toBeNull();
     expect(mockShowNotification).toHaveBeenCalledWith('error', expect.any(String));
   });
+
+  it('always sets startupComplete=true even if checkFileAccessible rejects', async () => {
+    localStorage.setItem('rekordboxLibraryPath', '/path/to/library.xml');
+    window.electronAPI.checkFileAccessible.mockRejectedValue(new Error('IPC failure'));
+
+    const { result } = renderHook(() => useLibrary(mockShowNotification));
+
+    await waitFor(() => expect(result.current.startupComplete).toBe(true));
+    expect(result.current.libraryPath).toBe('');
+    expect(result.current.libraryData).toBeNull();
+    expect(localStorage.getItem('rekordboxLibraryPath')).toBeNull();
+  });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
 
 export default defineConfig(({ mode }) => {
@@ -8,7 +9,7 @@ export default defineConfig(({ mode }) => {
   const port = parseInt(env.VITE_DEV_PORT) || 3000;
 
   return {
-    plugins: [react()],
+    plugins: [react(), tailwindcss()],
     base: './',
     build: {
       outDir: 'dist/renderer',


### PR DESCRIPTION
## Status: Ready for review ✅

## What changed

### Tailwind v4 migration
| Package | Before | After |
|---|---|---|
| `tailwindcss` | 3.4.x | 4.3.0 |
| `@tailwindcss/vite` | — | 4.3.0 (new) |
| `postcss.config.js` | `tailwindcss + autoprefixer` | deleted |

- `postcss.config.js` deleted — `@tailwindcss/vite` Vite plugin replaces it
- `index.css`: `@tailwind` directives → `@import "tailwindcss"` + full `@theme {}` block with all custom `te-*` tokens (colours, fonts, letter-spacing, border-radius, spacing, animations)
- `tailwind.config.js` retained as reference; can be deleted after team confirms migration

### Startup auto-load
On launch, if a library path was saved from a previous session:
- **File reachable** → parse and load while the splash screen shows; app opens with library ready
- **File gone/unreadable** → path forgotten, import page shown

Previously the app showed the saved path in the footer but required a manual re-load every session. Also removes the unreliable localStorage library-data serialisation (silently failed for any real-sized XML).

New IPC call: `checkFileAccessible(path)` — lightweight `fs.access` check, no XML parsing.
`AppWithRouter` splash now driven by `startupComplete` from `useLibrary` instead of a hardcoded 2-second timer.

## Test plan
- [x] `pnpm build` — clean (renderer + main)
- [x] `pnpm test:unit` — 138/138 passing (4 new tests for startup behaviour)
- [ ] Visual smoke test: confirm `te-*` colours, Orbitron/Space Mono fonts render correctly
- [ ] Launch with a saved library path — confirm it auto-loads through the splash
- [ ] Delete the saved XML, relaunch — confirm path is cleared, import page shown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App now attempts to auto-load a previously saved library on startup when that file is reachable; splash screen remains until startup completes.
  * Improved styling theme: consolidated Tailwind import and a full set of design tokens for consistent UI theming.

* **Bug Fixes**
  * Better handling when a saved library path is missing or inaccessible — stored path is cleared and user is shown import flow; failures surface a generic load error.

* **Tests**
  * Added unit tests covering startup auto-load success and failure scenarios.

* **Chores**
  * Modernized styling build integration and updated styling framework dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->