### PR TITLE
fix: relocator can't find findable files + stop uppercasing paths

### DIFF
--- a/src/renderer/components/DuplicateDetector.tsx
+++ b/src/renderer/components/DuplicateDetector.tsx
@@ -151,6 +151,10 @@ const DuplicateDetector: React.FC = () => {
   const scanForDuplicates = async () => {
     if (!libraryData) { return; }
     setIsScanning(true);
+    // Let the browser paint the "Scanning..." state before the heavy,
+    // synchronous work (Array.from over thousands of tracks + IPC clone)
+    // blocks the main thread — otherwise the UI looks frozen for seconds.
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
     try {
       const tracks = Array.from(libraryData.tracks.values());
       const result = await window.electronAPI.findDuplicates({
@@ -405,6 +409,14 @@ const DuplicateDetector: React.FC = () => {
               <CheckCircle2 size={48} className="mx-auto mb-4 text-green-500" />
               <h3 className="text-lg font-medium mb-2">No Duplicates Found</h3>
               <p>Your library appears to be clean! No duplicate tracks were detected.</p>
+            </div>
+          </div>
+        ) : isScanning ? (
+          <div className="flex-1 flex items-center justify-center">
+            <div className="text-center te-value">
+              <Loader2 size={48} className="mx-auto mb-4 text-te-orange animate-spin spinner-loading" />
+              <h3 className="te-title mb-2">Scanning your library…</h3>
+              <p>Comparing tracks for duplicates — this can take a moment on large libraries.</p>
             </div>
           </div>
         ) : isLoadingDuplicates ? (

--- a/src/renderer/components/MissingTrackItem.tsx
+++ b/src/renderer/components/MissingTrackItem.tsx
@@ -74,7 +74,7 @@ export const MissingTrackItem: React.FC<MissingTrackItemProps> = ({
           </div>
           <div className="mt-2 ml-6">
             <p className="te-label text-xs font-te-mono">
-              Missing: {track.originalLocation}
+              Missing: <span className="te-path">{track.originalLocation}</span>
             </p>
             {track.isUnlocatable && (
               <p className="text-te-orange text-xs font-semibold mt-1 font-te-mono">
@@ -83,7 +83,7 @@ export const MissingTrackItem: React.FC<MissingTrackItemProps> = ({
             )}
             {hasRelocation && relocationPath && (
               <p className="text-te-green-500 text-xs font-te-mono mt-1">
-                → Relocate to: {relocationPath}
+                → Relocate to: <span className="te-path">{relocationPath}</span>
               </p>
             )}
           </div>

--- a/src/renderer/components/RelocationHistoryPanel.tsx
+++ b/src/renderer/components/RelocationHistoryPanel.tsx
@@ -263,7 +263,7 @@ export const RelocationHistoryPanel: React.FC<RelocationHistoryPanelProps> = ({
                   <div className="space-y-1.5">
                     <div className="flex items-center space-x-2">
                       <span className="text-xs text-te-grey-500">From:</span>
-                      <p className="text-xs te-label font-te-mono truncate flex-1" title={entry.originalLocation}>
+                      <p className="text-xs te-path text-te-grey-600 truncate flex-1" title={entry.originalLocation}>
                         {entry.originalLocation}
                       </p>
                     </div>

--- a/src/renderer/components/TrackRelocator.tsx
+++ b/src/renderer/components/TrackRelocator.tsx
@@ -302,12 +302,12 @@ const TrackRelocator: React.FC = () => {
             disabled={isRelocating || relocations.size === 0}
             loading={isRelocating}
             icon={Target}
-            title="Apply Manual Relocations"
-            description="Apply all manually configured track relocations to update file paths in your library"
+            title="Apply queued relocations"
+            description="Write the relocations you picked (click a candidate to queue one) to your library XML, with a backup"
             variant="success"
             className="w-full text-xs"
           >
-            Manual ({relocations.size})
+            Apply ({relocations.size})
           </PopoverButton>
         </div>
 
@@ -434,7 +434,11 @@ const TrackRelocator: React.FC = () => {
                   </p>
                 </div>
               ) : (
-                candidates.map((candidate, index) => (
+                <>
+                <p className="te-label text-xs mb-2 normal-case">
+                  Click a match to queue it, then press <span className="te-value">Apply</span> at the top to write it to your library.
+                </p>
+                {candidates.map((candidate, index) => (
                   <div
                     key={index}
                     className="card cursor-pointer hover:bg-te-grey-100 transition-colors"
@@ -475,7 +479,8 @@ const TrackRelocator: React.FC = () => {
                       </button>
                     </div>
                   </div>
-                ))
+                ))}
+                </>
               )}
             </div>
           </div>

--- a/src/renderer/components/TrackRelocator.tsx
+++ b/src/renderer/components/TrackRelocator.tsx
@@ -445,7 +445,7 @@ const TrackRelocator: React.FC = () => {
                         <p className="te-value text-sm font-medium truncate">
                           {candidate.path.split('/').pop()}
                         </p>
-                        <p className="te-label text-xs font-te-mono">
+                        <p className="te-path text-xs text-te-grey-600 break-all">
                           {candidate.path}
                         </p>
                         <div className="flex items-center space-x-2 mt-1">

--- a/src/renderer/hooks/useTrackRelocator.ts
+++ b/src/renderer/hooks/useTrackRelocator.ts
@@ -204,9 +204,11 @@ export function useTrackRelocator(
       return;
     }
 
-    // Check cache first
+    // Check cache first — but an empty cached result is a cache MISS, not a
+    // "no matches" answer. A stale empty array (e.g. cached before search
+    // paths were configured) would otherwise permanently hide a findable file.
     const cachedCandidates = relocationCandidatesCache.get(track.id);
-    if (cachedCandidates) {
+    if (cachedCandidates && cachedCandidates.length > 0) {
       setState(prev => ({
         ...prev,
         selectedTrack: track,

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -120,6 +120,11 @@
     @apply font-te-mono text-xs font-medium text-te-grey-600 uppercase tracking-wider;
   }
   
+  /* Filesystem paths: monospace, never uppercased (paths are case-bearing). */
+  .te-path {
+    @apply font-te-mono normal-case tracking-normal;
+  }
+
   .te-value {
     @apply font-te-mono text-sm font-semibold text-te-grey-800 tracking-wide;
   }


### PR DESCRIPTION
## Problem

Two issues reported against v0.2.0:

1. **FIND returned no candidates for files that clearly exist on disk.** A track missing at `~/Music/.../01 Rattlesnake.mp3`, with the real file present at `/Volumes/ICYFAST BLA/.../01 Rattlesnake.mp3` and that volume configured as a search path, could not be found.
2. **File paths were rendered ALL-CAPS**, which is misleading for case-bearing filesystem paths.

## Root cause (issue 1)

The backend search is correct — reproduced against the real volume, the exact match is found in ~3s. The bug was in the renderer cache: `relocationCandidatesCache.get(track.id)` returns an empty array `[]` from a prior search (e.g. one run before search paths were configured). `[]` is truthy, so the cache-hit guard short-circuited and returned "0 candidates" forever, never re-searching.

## Fix

1. Treat an empty cached entry as a cache **miss** (`cachedCandidates.length > 0`) so it re-searches. Self-heals already-poisoned caches — no migration needed.
2. New `.te-path` CSS helper (monospace, `normal-case`) applied to the missing-track path, relocation target, and history-panel From path. `.te-label`'s `uppercase` no longer hits path strings.

## Test plan

- 186 unit tests green; `pnpm build` clean.
- Backend find verified end-to-end against the real 17,941-file volume (exact match returned).
- Manual: FIND on a previously-stuck track now returns the match; paths render in normal case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)