### PR TITLE
fix: keep playlists complete on duplicate resolution + show playlist reach

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'url';
 import { mediaUrlToFilePath, isAllowedMediaPath } from './mediaProtocol';
 import { RekordboxParser } from './rekordboxParser';
 import { DuplicateDetector } from './duplicateDetector';
+import { substitutePlaylistTrackIds } from './playlistSubstitution';
 import { Logger } from './logger';
 import { TrackRelocator } from './trackRelocator';
 import { isLossless } from './audioQuality';
@@ -441,6 +442,9 @@ ipcMain.handle('resolve-duplicates', async (_, resolution: {
 
     // Step 3: Determine which tracks to remove for each duplicate set
     const tracksToRemove: string[] = [];
+    // removedTrackId -> keptTrackId, so playlist references can be re-pointed
+    // (not dropped) and playlists stay complete.
+    const replacement = new Map<string, string>();
 
     for (const duplicateSet of resolution.duplicates) {
       const tracksInSet = duplicateSet.tracks;
@@ -496,6 +500,7 @@ ipcMain.handle('resolve-duplicates', async (_, resolution: {
         .filter((track: any) => track.id !== trackToKeep.id);
 
       tracksToRemove.push(...tracksToRemoveFromSet.map((t: any) => t.id));
+      tracksToRemoveFromSet.forEach((t: any) => replacement.set(t.id, trackToKeep.id));
 
       safeConsole.log(`🎵 Duplicate set: keeping "${trackToKeep.name}" (${trackToKeep.location}), removing ${tracksToRemoveFromSet.length} others`);
     }
@@ -515,29 +520,11 @@ ipcMain.handle('resolve-duplicates', async (_, resolution: {
       library.tracks.delete(trackId);
     });
 
-    // Remove from playlists (recursive function to handle nested playlist structure)
-    const removeTracksFromPlaylists = (playlists: any[]) => {
-      playlists.forEach((playlist: any) => {
-        // Filter tracks from current playlist
-        if (playlist.tracks) {
-          const originalCount = playlist.tracks.length;
-          playlist.tracks = playlist.tracks.filter((trackId: string) =>
-            !tracksToRemove.includes(trackId)
-          );
-          const removedCount = originalCount - playlist.tracks.length;
-          if (removedCount > 0) {
-            safeConsole.log(`🎵 Removed ${removedCount} duplicate tracks from playlist "${playlist.name}"`);
-          }
-        }
-
-        // Recursively process child playlists
-        if (playlist.children && playlist.children.length > 0) {
-          removeTracksFromPlaylists(playlist.children);
-        }
-      });
-    };
-
-    removeTracksFromPlaylists(library.playlists);
+    // Re-point playlist references from each removed track to the kept track,
+    // so playlists stay complete (a song that lived only in the removed
+    // duplicate is preserved, now pointing at the kept file) and no playlist
+    // gains a duplicate entry.
+    substitutePlaylistTrackIds(library.playlists, replacement);
 
     // Step 5: Save updated library
     await rekordboxParser.saveLibrary(library, resolution.libraryPath);

--- a/src/main/playlistSubstitution.ts
+++ b/src/main/playlistSubstitution.ts
@@ -1,0 +1,34 @@
+/**
+ * When a duplicate set is resolved, the removed tracks must not simply
+ * vanish from playlists — every playlist that referenced any version of the
+ * song must keep it, now pointing at the single kept track. This rewrites
+ * playlist track-id lists in place: each removed id is replaced by its kept
+ * id, and the resulting list is de-duplicated while preserving the order of
+ * first appearance (so a playlist that already contained the kept track
+ * doesn't gain a second entry).
+ *
+ * @param playlists  the (possibly nested) playlist tree; `tracks` arrays are rewritten in place
+ * @param replacement  removedTrackId -> keptTrackId
+ */
+export function substitutePlaylistTrackIds(
+  playlists: Array<{ tracks?: string[]; children?: any[] }>,
+  replacement: Map<string, string>
+): void {
+  for (const playlist of playlists) {
+    if (playlist.tracks) {
+      const seen = new Set<string>();
+      const rewritten: string[] = [];
+      for (const id of playlist.tracks) {
+        const mapped = replacement.get(id) ?? id;
+        if (!seen.has(mapped)) {
+          seen.add(mapped);
+          rewritten.push(mapped);
+        }
+      }
+      playlist.tracks = rewritten;
+    }
+    if (playlist.children && playlist.children.length > 0) {
+      substitutePlaylistTrackIds(playlist.children, replacement);
+    }
+  }
+}

--- a/src/renderer/components/DuplicateDetector.tsx
+++ b/src/renderer/components/DuplicateDetector.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Search,
   Settings,
@@ -14,9 +14,17 @@ import { useAppContext } from '../AppWithRouter';
 import { VirtualizedDuplicateList } from './VirtualizedDuplicateList';
 import { SettingsSlideout, PopoverButton, PageHeader, DeleteConfirmModal } from './ui';
 import { SettingsPanel } from './SettingsPanel';
+import { countPlaylistMembership } from '../utils/playlistMembership';
 
 const DuplicateDetector: React.FC = () => {
   const { libraryData, libraryPath, showNotification, setLibraryData } = useAppContext();
+
+  // How many playlists each track belongs to — shown in each duplicate row so
+  // you can see a track's playlist reach before choosing which copy to keep.
+  const playlistMembership = useMemo(
+    () => (libraryData ? countPlaylistMembership(libraryData.playlists) : new Map()),
+    [libraryData]
+  );
 
   // Use the custom duplicates hook
   const {
@@ -400,6 +408,7 @@ const DuplicateDetector: React.FC = () => {
                 selectedDuplicates={selectedDuplicates}
                 onToggleSelection={toggleDuplicateSelection}
                 resolutionStrategy={resolutionStrategy}
+                playlistMembership={playlistMembership}
               />
             </div>
           </div>

--- a/src/renderer/components/DuplicateItem.tsx
+++ b/src/renderer/components/DuplicateItem.tsx
@@ -24,13 +24,15 @@ interface DuplicateItemProps {
   isSelected: boolean;
   onToggleSelection: () => void;
   resolutionStrategy: string;
+  playlistMembership?: Map<string, { count: number; names: string[] }>;
 }
 
 const DuplicateItem: React.FC<DuplicateItemProps> = memo(({
   duplicate,
   isSelected,
   onToggleSelection,
-  resolutionStrategy
+  resolutionStrategy,
+  playlistMembership
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [selectedTrackId, setSelectedTrackId] = useState<string | null>(null);
@@ -101,6 +103,18 @@ const DuplicateItem: React.FC<DuplicateItemProps> = memo(({
   }, [duplicate.tracks, resolutionStrategy, duplicate.pathPreferences]);
 
 
+  // Total playlist reach of this song across ALL its duplicate copies (the
+  // union of every copy's playlists). After we reduce the set to one file,
+  // that single file ends up in all of these playlists.
+  const playlistReach = useMemo(() => {
+    const names = new Set<string>();
+    for (const track of duplicate.tracks) {
+      const m = playlistMembership?.get(track.id);
+      if (m) { m.names.forEach((n) => names.add(n)); }
+    }
+    return { count: names.size, names: Array.from(names) };
+  }, [duplicate.tracks, playlistMembership]);
+
   const toggleExpanded = useCallback(() => {
     setIsExpanded(prev => !prev);
   }, []);
@@ -148,6 +162,13 @@ const DuplicateItem: React.FC<DuplicateItemProps> = memo(({
               <span className="text-xs text-zinc-400">•</span>
               <span className="text-xs text-zinc-400 capitalize">
                 {duplicate.matchType} match
+              </span>
+              <span className="text-xs text-zinc-400">•</span>
+              <span
+                className="text-xs text-te-grey-500 font-te-mono"
+                title={playlistReach.count > 0 ? playlistReach.names.join('\n') : undefined}
+              >
+                in {playlistReach.count} playlist{playlistReach.count === 1 ? '' : 's'}
               </span>
               <ConfidenceBadge confidence={duplicate.confidence} />
             </div>

--- a/src/renderer/components/VirtualizedDuplicateList.tsx
+++ b/src/renderer/components/VirtualizedDuplicateList.tsx
@@ -8,13 +8,15 @@ interface VirtualizedDuplicateListProps {
   selectedDuplicates: Set<string>;
   onToggleSelection: (id: string) => void;
   resolutionStrategy: ResolutionStrategy;
+  playlistMembership: Map<string, { count: number; names: string[] }>;
 }
 
 export const VirtualizedDuplicateList: React.FC<VirtualizedDuplicateListProps> = ({
   duplicates,
   selectedDuplicates,
   onToggleSelection,
-  resolutionStrategy
+  resolutionStrategy,
+  playlistMembership
 }) => {
   console.log('🎯 VirtualizedDuplicateList render:', {
     duplicatesCount: duplicates.length,
@@ -32,6 +34,7 @@ export const VirtualizedDuplicateList: React.FC<VirtualizedDuplicateListProps> =
           isSelected={selectedDuplicates.has(duplicate.id)}
           onToggleSelection={() => onToggleSelection(duplicate.id)}
           resolutionStrategy={resolutionStrategy}
+          playlistMembership={playlistMembership}
         />
       )}
       emptyState={<div className="p-5 te-value">No duplicates to show</div>}

--- a/src/renderer/utils/playlistMembership.ts
+++ b/src/renderer/utils/playlistMembership.ts
@@ -1,0 +1,35 @@
+import type { Playlist } from '../types';
+
+/**
+ * Count how many playlists each track belongs to, and collect the playlist
+ * names. Folders (type 'FOLDER') are containers, not real playlists, so their
+ * own `tracks` array (normally empty) is ignored for the count; their children
+ * are still walked. A track appearing twice in the same playlist counts once.
+ */
+export function countPlaylistMembership(
+  playlists: Playlist[]
+): Map<string, { count: number; names: string[] }> {
+  const membership = new Map<string, { count: number; names: string[] }>();
+
+  const walk = (nodes: Playlist[]) => {
+    for (const node of nodes) {
+      if (node.type !== 'FOLDER' && node.tracks && node.tracks.length > 0) {
+        const seenInThisPlaylist = new Set<string>();
+        for (const trackId of node.tracks) {
+          if (seenInThisPlaylist.has(trackId)) { continue; }
+          seenInThisPlaylist.add(trackId);
+          const entry = membership.get(trackId) ?? { count: 0, names: [] };
+          entry.count += 1;
+          entry.names.push(node.name);
+          membership.set(trackId, entry);
+        }
+      }
+      if (node.children && node.children.length > 0) {
+        walk(node.children);
+      }
+    }
+  };
+
+  walk(playlists);
+  return membership;
+}

--- a/tests/unit/playlist-membership.test.ts
+++ b/tests/unit/playlist-membership.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { countPlaylistMembership } from '../../src/renderer/utils/playlistMembership';
+import type { Playlist } from '../../src/renderer/types';
+
+const pl = (name: string, tracks: string[]): Playlist => ({ name, tracks, type: 'PLAYLIST' });
+const folder = (name: string, children: Playlist[]): Playlist => ({ name, tracks: [], type: 'FOLDER', children });
+
+describe('countPlaylistMembership', () => {
+  it('counts how many playlists a track is in and names them', () => {
+    const m = countPlaylistMembership([pl('Set A', ['t1', 't2']), pl('Set B', ['t1'])]);
+    expect(m.get('t1')).toEqual({ count: 2, names: ['Set A', 'Set B'] });
+    expect(m.get('t2')).toEqual({ count: 1, names: ['Set A'] });
+  });
+
+  it('does not count a track twice within the same playlist', () => {
+    const m = countPlaylistMembership([pl('Set A', ['t1', 't1', 't2'])]);
+    expect(m.get('t1')!.count).toBe(1);
+  });
+
+  it('walks nested folders but ignores folder containers themselves', () => {
+    const tree = [folder('Crates', [pl('Deep', ['t1']), folder('More', [pl('Deeper', ['t1'])])])];
+    const m = countPlaylistMembership(tree);
+    expect(m.get('t1')).toEqual({ count: 2, names: ['Deep', 'Deeper'] });
+  });
+
+  it('returns nothing for a track in no playlist', () => {
+    const m = countPlaylistMembership([pl('Set A', ['t1'])]);
+    expect(m.get('t2')).toBeUndefined();
+  });
+});

--- a/tests/unit/playlist-substitution.test.ts
+++ b/tests/unit/playlist-substitution.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { substitutePlaylistTrackIds } from '../../src/main/playlistSubstitution';
+
+describe('substitutePlaylistTrackIds', () => {
+  it('replaces a removed track id with the kept id, keeping the playlist complete', () => {
+    const playlists = [{ name: 'Set', tracks: ['a', 'B', 'c'] }];
+    substitutePlaylistTrackIds(playlists, new Map([['B', 'A']]));
+    expect(playlists[0].tracks).toEqual(['a', 'A', 'c']);
+  });
+
+  it('does not create a duplicate when the kept track is already in the playlist', () => {
+    // playlist has both the kept (A) and the removed (B) version of the song
+    const playlists = [{ name: 'Set', tracks: ['A', 'x', 'B'] }];
+    substitutePlaylistTrackIds(playlists, new Map([['B', 'A']]));
+    expect(playlists[0].tracks).toEqual(['A', 'x']);
+  });
+
+  it('preserves order of first appearance when kept comes after removed', () => {
+    const playlists = [{ name: 'Set', tracks: ['B', 'y', 'A'] }];
+    substitutePlaylistTrackIds(playlists, new Map([['B', 'A']]));
+    expect(playlists[0].tracks).toEqual(['A', 'y']);
+  });
+
+  it('recurses into nested folders', () => {
+    const playlists = [
+      { name: 'Folder', tracks: [], children: [{ name: 'Inner', tracks: ['B', 'c'] }] },
+    ];
+    substitutePlaylistTrackIds(playlists, new Map([['B', 'A']]));
+    expect((playlists[0].children![0] as any).tracks).toEqual(['A', 'c']);
+  });
+
+  it('collapses several removed versions of one song into a single kept entry', () => {
+    // three duplicates B, C, D all resolve to kept A, all present in the playlist
+    const playlists = [{ name: 'Set', tracks: ['B', 'C', 'z', 'D'] }];
+    substitutePlaylistTrackIds(playlists, new Map([['B', 'A'], ['C', 'A'], ['D', 'A']]));
+    expect(playlists[0].tracks).toEqual(['A', 'z']);
+  });
+
+  it('leaves unrelated playlists untouched', () => {
+    const playlists = [{ name: 'Other', tracks: ['x', 'y'] }];
+    substitutePlaylistTrackIds(playlists, new Map([['B', 'A']]));
+    expect(playlists[0].tracks).toEqual(['x', 'y']);
+  });
+});


### PR DESCRIPTION
## Critical fix — playlist integrity

Resolving a duplicate used to **filter** the removed track out of every playlist. Any playlist that contained only the removed copy (not the kept one) **silently lost the song**. This shipped in v0.2.1.

Now each removed track's playlist references are **re-pointed** to the kept track (deduped, order preserved). Every playlist that had any version of the song keeps it, now pointing at the single kept file. Files stay unique on disk; playlists stay whole. Pure `substitutePlaylistTrackIds` helper, 6 unit tests.

## Feature — playlist reach per duplicate set

Each duplicate row shows **"in N playlists"** — the union of every copy's playlist memberships (hover for names). That's the reach the single kept file inherits after reduction. Pure `countPlaylistMembership` helper, 4 unit tests.

## Test plan

- 196 unit tests green; `pnpm build` clean.
- Verified in the running app: duplicate rows show total playlist reach; resolving a duplicate keeps every playlist complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Duplicate tracks now show how many playlists contain them, with playlist names available in a tooltip.
  - Removing duplicates preserves playlist entries by replacing removed tracks with their retained equivalents.
  - Nested playlists are updated while preserving track order and removing repeated entries.

- **Bug Fixes**
  - Playlist references to duplicate tracks are no longer removed unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->