### PR TITLE
fix: never delete a file a kept track still points at (data loss)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5,6 +5,7 @@ import { mediaUrlToFilePath, isAllowedMediaPath } from './mediaProtocol';
 import { RekordboxParser } from './rekordboxParser';
 import { DuplicateDetector } from './duplicateDetector';
 import { substitutePlaylistTrackIds } from './playlistSubstitution';
+import { computeDeletablePaths } from './safeDeletePaths';
 import { Logger } from './logger';
 import { TrackRelocator } from './trackRelocator';
 import { isLossless } from './audioQuality';
@@ -532,19 +533,32 @@ ipcMain.handle('resolve-duplicates', async (_, resolution: {
     safeConsole.log(`✅ Successfully resolved duplicates: removed ${tracksToRemove.length} tracks`);
     logger.logLibrarySaving(resolution.libraryPath, library.tracks.size);
 
-    // Step 6 (optional): Delete files from disk
+    // Step 6 (optional): Delete files from disk.
+    // Several rekordbox entries can point at the SAME file. Only delete a path
+    // that no remaining track still references, or we would destroy the audio
+    // belonging to a track the user chose to keep.
+    const remainingLocations = Array.from(library.tracks.values())
+      .map((t: any) => t?.location)
+      .filter((loc: any): loc is string => typeof loc === 'string' && loc.length > 0);
+    const deletablePaths = computeDeletablePaths(locationsToDelete, remainingLocations);
+    const skippedStillReferenced = locationsToDelete.length - deletablePaths.length;
+    if (skippedStillReferenced > 0) {
+      safeConsole.log(`🛡️ Skipped ${skippedStillReferenced} path(s) still referenced by kept tracks or duplicated in the delete list`);
+    }
+
     const deleteResults = { deleted: 0, failed: [] as { file: string; error: string }[] };
-    if (resolution.deleteFromDisk && locationsToDelete.length > 0) {
-      const fsSync = require('fs');
-      for (const loc of locationsToDelete) {
+    if (resolution.deleteFromDisk && deletablePaths.length > 0) {
+      for (const loc of deletablePaths) {
         try {
-          fsSync.unlinkSync(loc);
+          // Move to the OS trash rather than unlinking, so a wrong call is
+          // recoverable by the user instead of destroying audio permanently.
+          await shell.trashItem(loc);
           deleteResults.deleted++;
-          safeConsole.log(`🗑️ Deleted from disk: ${loc}`);
+          safeConsole.log(`🗑️ Moved to trash: ${loc}`);
         } catch (err) {
           const msg = err instanceof Error ? err.message : 'Unknown error';
           deleteResults.failed.push({ file: loc, error: msg });
-          safeConsole.error(`❌ Failed to delete ${loc}: ${msg}`);
+          safeConsole.error(`❌ Failed to trash ${loc}: ${msg}`);
         }
       }
     }

--- a/src/main/safeDeletePaths.ts
+++ b/src/main/safeDeletePaths.ts
@@ -1,0 +1,35 @@
+/**
+ * Decide which files may actually be deleted from disk after duplicate
+ * resolution.
+ *
+ * Rekordbox libraries can contain several track entries pointing at the SAME
+ * file on disk. Deleting the "losing" entries' paths would then delete the very
+ * file a kept entry still references — destroying audio the user chose to keep.
+ *
+ * A path is safe to delete only when NO track remaining in the library still
+ * references it. Paths are also de-duplicated so the same file is never
+ * unlinked twice (which produced spurious ENOENT failures).
+ *
+ * Comparison is case-insensitive: macOS and Windows filesystems are typically
+ * case-insensitive, so two entries differing only in case are the same file.
+ */
+export function computeDeletablePaths(
+  candidatePaths: string[],
+  remainingLocations: Iterable<string>
+): string[] {
+  const stillReferenced = new Set<string>();
+  for (const loc of remainingLocations) {
+    if (loc) { stillReferenced.add(loc.toLowerCase()); }
+  }
+
+  const seen = new Set<string>();
+  const deletable: string[] = [];
+  for (const path of candidatePaths) {
+    if (!path) { continue; }
+    const key = path.toLowerCase();
+    if (stillReferenced.has(key) || seen.has(key)) { continue; }
+    seen.add(key);
+    deletable.push(path);
+  }
+  return deletable;
+}

--- a/src/renderer/components/DuplicateDetector.tsx
+++ b/src/renderer/components/DuplicateDetector.tsx
@@ -15,6 +15,7 @@ import { VirtualizedDuplicateList } from './VirtualizedDuplicateList';
 import { SettingsSlideout, PopoverButton, PageHeader, DeleteConfirmModal } from './ui';
 import { SettingsPanel } from './SettingsPanel';
 import { countPlaylistMembership } from '../utils/playlistMembership';
+import { pickRecommendedTrack } from '../utils/pickRecommendedTrack';
 
 const DuplicateDetector: React.FC = () => {
   const { libraryData, libraryPath, showNotification, setLibraryData } = useAppContext();
@@ -258,12 +259,18 @@ const DuplicateDetector: React.FC = () => {
     if (deleteFromDisk) {
       // Collect all file paths that will be removed so the modal can show them
       const selectedSets = duplicates.filter(d => selectedDuplicates.has(d.id));
-      // We don't know which track "wins" client-side perfectly, but we show all paths —
-      // the backend will only delete the losers. Show a conservative "up to N files" list.
-      const allPaths = selectedSets.flatMap((d: any) =>
-        d.tracks.map((t: any) => t.location).filter(Boolean)
-      );
-      setPendingDeletePaths(allPaths);
+      // Show only the paths that will actually be trashed: per set, drop the
+      // copy that is kept, and drop any path the kept copy still uses (several
+      // rekordbox entries can point at the same file — that file stays).
+      const losingPaths = selectedSets.flatMap((d: any) => {
+        const keeper = pickRecommendedTrack(d.tracks, resolutionStrategy, d.pathPreferences);
+        const keeperLocation = (keeper?.location ?? '').toLowerCase();
+        return d.tracks
+          .filter((t: any) => t.id !== keeper?.id)
+          .map((t: any) => t.location)
+          .filter((loc: string) => loc && loc.toLowerCase() !== keeperLocation);
+      });
+      setPendingDeletePaths(Array.from(new Set(losingPaths)));
       return;
     }
 

--- a/src/renderer/components/DuplicateItem.tsx
+++ b/src/renderer/components/DuplicateItem.tsx
@@ -14,6 +14,7 @@ import { formatFileSize, formatDuration } from '../utils';
 import { useFileOperations } from '../hooks';
 import { ConfidenceBadge, PlayButton } from './ui';
 import { useSettingsStore } from '../stores/settingsStore';
+import { pickRecommendedTrack } from '../utils/pickRecommendedTrack';
 
 const _ext = (loc: string) => '.' + ((loc || '').split('.').pop()?.toLowerCase() ?? '');
 const isUniversalLossless = (loc: string) => ['.wav', '.aiff', '.aif'].includes(_ext(loc));
@@ -40,67 +41,10 @@ const DuplicateItem: React.FC<DuplicateItemProps> = memo(({
   const { openFileLocation } = useFileOperations();
   const preferLossless = useSettingsStore((state) => state.scanOptions.preferLossless);
 
-  const recommendedTrack = useMemo(() => {
-    if (resolutionStrategy === 'manual') {return null;}
-
-    let recommended = duplicate.tracks[0];
-
-    if (resolutionStrategy === 'keep-highest-quality') {
-      const qualityScore = (t: any) => (t.bitrate || 0) + (t.size || 0) / 1000000;
-      const tier = (t: any) => {
-        if (isUniversalLossless(t.location || '')) return 2;
-        if (preferLossless && isFlac(t.location || '')) return 2;
-        return 0;
-      };
-      recommended = duplicate.tracks.reduce((best: any, current: any) => {
-        const bt = tier(best); const ct = tier(current);
-        if (ct > bt) return current;
-        if (bt > ct) return best;
-        return qualityScore(current) > qualityScore(best) ? current : best;
-      });
-    } else if (resolutionStrategy === 'keep-newest') {
-      recommended = duplicate.tracks.reduce((newest: any, current: any) => {
-        if (!newest.dateModified) {return current;}
-        if (!current.dateModified) {return newest;}
-        return new Date(current.dateModified) > new Date(newest.dateModified) ? current : newest;
-      });
-    } else if (resolutionStrategy === 'keep-oldest') {
-      recommended = duplicate.tracks.reduce((oldest: any, current: any) => {
-        if (!oldest.dateAdded) {return current;}
-        if (!current.dateAdded) {return oldest;}
-        return new Date(current.dateAdded) < new Date(oldest.dateAdded) ? current : oldest;
-      });
-    } else if (resolutionStrategy === 'keep-preferred-path') {
-      // Find track with path that matches any of the preferred paths
-      const pathPreferences = duplicate.pathPreferences || [];
-      console.log('🔍 Path preferences:', pathPreferences);
-
-      if (pathPreferences.length > 0) {
-        // Sort tracks by preference priority (lower index = higher priority)
-        const sortedTracks = [...duplicate.tracks].sort((a: any, b: any) => {
-          const aMatch = pathPreferences.findIndex((pref: string) =>
-            a.location && a.location.toLowerCase().includes(pref.toLowerCase())
-          );
-          const bMatch = pathPreferences.findIndex((pref: string) =>
-            b.location && b.location.toLowerCase().includes(pref.toLowerCase())
-          );
-
-          // If both match, return the one with lower index (higher priority)
-          if (aMatch !== -1 && bMatch !== -1) {return aMatch - bMatch;}
-          // If only one matches, prioritize the matching one
-          if (aMatch !== -1) {return -1;}
-          if (bMatch !== -1) {return 1;}
-          // If neither match, keep original order
-          return 0;
-        });
-
-        recommended = sortedTracks[0];
-        console.log('📁 Recommended track by path preference:', recommended?.location);
-      }
-    }
-
-    return recommended;
-  }, [duplicate.tracks, resolutionStrategy, duplicate.pathPreferences]);
+  const recommendedTrack = useMemo(
+    () => pickRecommendedTrack(duplicate.tracks, resolutionStrategy, duplicate.pathPreferences, preferLossless),
+    [duplicate.tracks, resolutionStrategy, duplicate.pathPreferences, preferLossless]
+  );
 
 
   // Total playlist reach of this song across ALL its duplicate copies (the

--- a/src/renderer/utils/pickRecommendedTrack.ts
+++ b/src/renderer/utils/pickRecommendedTrack.ts
@@ -1,0 +1,69 @@
+const ext = (loc: string) => {
+  const i = (loc || '').lastIndexOf('.');
+  return i === -1 ? '' : loc.slice(i).toLowerCase();
+};
+const isUniversalLossless = (loc: string) => ['.wav', '.aiff', '.aif'].includes(ext(loc));
+const isFlac = (loc: string) => ext(loc) === '.flac';
+
+/**
+ * Which copy of a duplicate set the current strategy would keep.
+ * Shared by the duplicate row (to badge the recommended copy) and by the
+ * delete-confirmation modal (to list only the copies that will be trashed),
+ * so both agree on the winner. Mirrors the main process's resolution rules.
+ * Returns null for the 'manual' strategy, where the user picks.
+ */
+export function pickRecommendedTrack(
+  tracks: any[],
+  resolutionStrategy: string,
+  pathPreferences: string[] = [],
+  preferLossless = false
+): any | null {
+  if (resolutionStrategy === 'manual' || !tracks || tracks.length === 0) { return null; }
+
+  if (resolutionStrategy === 'keep-highest-quality') {
+    const qualityScore = (t: any) => (t.bitrate || 0) + (t.size || 0) / 1000000;
+    const tier = (t: any) => {
+      if (isUniversalLossless(t.location || '')) { return 2; }
+      if (preferLossless && isFlac(t.location || '')) { return 2; }
+      return 0;
+    };
+    return tracks.reduce((best: any, current: any) => {
+      const bt = tier(best); const ct = tier(current);
+      if (ct > bt) { return current; }
+      if (bt > ct) { return best; }
+      return qualityScore(current) > qualityScore(best) ? current : best;
+    });
+  }
+
+  if (resolutionStrategy === 'keep-newest') {
+    return tracks.reduce((newest: any, current: any) => {
+      if (!newest.dateModified) { return current; }
+      if (!current.dateModified) { return newest; }
+      return new Date(current.dateModified) > new Date(newest.dateModified) ? current : newest;
+    });
+  }
+
+  if (resolutionStrategy === 'keep-oldest') {
+    return tracks.reduce((oldest: any, current: any) => {
+      if (!oldest.dateAdded) { return current; }
+      if (!current.dateAdded) { return oldest; }
+      return new Date(current.dateAdded) < new Date(oldest.dateAdded) ? current : oldest;
+    });
+  }
+
+  if (resolutionStrategy === 'keep-preferred-path' && pathPreferences.length > 0) {
+    const sorted = [...tracks].sort((a: any, b: any) => {
+      const aMatch = pathPreferences.findIndex((pref) =>
+        a.location && a.location.toLowerCase().includes(pref.toLowerCase()));
+      const bMatch = pathPreferences.findIndex((pref) =>
+        b.location && b.location.toLowerCase().includes(pref.toLowerCase()));
+      if (aMatch !== -1 && bMatch !== -1) { return aMatch - bMatch; }
+      if (aMatch !== -1) { return -1; }
+      if (bMatch !== -1) { return 1; }
+      return 0;
+    });
+    return sorted[0];
+  }
+
+  return tracks[0];
+}

--- a/tests/unit/safe-delete-paths.test.ts
+++ b/tests/unit/safe-delete-paths.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { computeDeletablePaths } from '../../src/main/safeDeletePaths';
+
+describe('computeDeletablePaths', () => {
+  it('never deletes a file a remaining track still points at', () => {
+    // The real bug: 3 XML entries share one file; 2 are removed, 1 is kept.
+    const kept = '/Music/Bruxelles arrive.mp3';
+    const result = computeDeletablePaths([kept, kept], [kept]);
+    expect(result).toEqual([]);
+  });
+
+  it('deletes paths no remaining track references', () => {
+    const result = computeDeletablePaths(['/Music/loser.mp3'], ['/Music/keeper.mp3']);
+    expect(result).toEqual(['/Music/loser.mp3']);
+  });
+
+  it('de-duplicates repeated paths so a file is unlinked once', () => {
+    const result = computeDeletablePaths(
+      ['/Music/dup.mp3', '/Music/dup.mp3', '/Music/other.mp3'],
+      []
+    );
+    expect(result).toEqual(['/Music/dup.mp3', '/Music/other.mp3']);
+  });
+
+  it('treats paths differing only in case as the same file', () => {
+    const result = computeDeletablePaths(['/Music/Song.mp3'], ['/music/song.MP3']);
+    expect(result).toEqual([]);
+  });
+
+  it('ignores empty or missing locations', () => {
+    const result = computeDeletablePaths(['', '/Music/real.mp3'], ['', undefined as any]);
+    expect(result).toEqual(['/Music/real.mp3']);
+  });
+
+  it('handles the mixed case: some losers share the kept file, others do not', () => {
+    const kept = '/Music/keeper.mp3';
+    const result = computeDeletablePaths(
+      [kept, '/Music/real-loser.mp3', kept, '/Music/real-loser.mp3'],
+      [kept, '/Music/untouched.mp3']
+    );
+    expect(result).toEqual(['/Music/real-loser.mp3']);
+  });
+});


### PR DESCRIPTION
## Critical — this destroyed user audio

Rekordbox can hold several entries for the **same file**. Resolving such a duplicate set deleted the losing entries' paths — which are the *kept* track's path — so the audio the user chose to keep was permanently unlinked and its entry left dangling.

Confirmed from a real user log: a 3-entry set deleted its own kept file, then failed the second unlink with ENOENT.

```
keeping "Bruxelles arrive" (/Volumes/.../Bruxelles arrive.mp3), removing 2 others
🗑️ Deleted from disk: /Volumes/.../Bruxelles arrive.mp3      ← the kept file
❌ Failed to delete /Volumes/.../Bruxelles arrive.mp3: ENOENT
```

## Fixes

- **`computeDeletablePaths`** — only trash a path that **no remaining track references**; de-duplicated; case-insensitive (macOS/Windows filesystems are). 6 unit tests covering the shared-path case, dedup, mixed sets.
- **Trash, not unlink** — `shell.trashItem` so a wrong call is recoverable.
- **Honest confirmation count** — the modal listed *every* path in the selected sets including the kept copies (the "11 files" that produced 5 deletions). It now lists only what will actually be trashed.
- **`pickRecommendedTrack` extracted** so the modal and the duplicate row agree on which copy wins.

Intended behaviour is unchanged and now actually correct: point all references at the best copy, then remove the remaining copies — never the best one.

## Test plan

- 202 unit tests green; `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)