### PR TITLE
feat: History tab, duplicate-kind filter, faster navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "fake-indexeddb": "^6.2.5",
     "happy-dom": "^20.10.1",
     "jsdom": "^29.1.1",
     "playwright": "^1.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.57.1)
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       happy-dom:
         specifier: ^20.10.1
         version: 20.10.1
@@ -2243,6 +2246,10 @@ packages:
   extsprintf@1.4.1:
     resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
     engines: {'0': node >=0.6.0}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -6435,6 +6442,8 @@ snapshots:
 
   extsprintf@1.4.1:
     optional: true
+
+  fake-indexeddb@6.2.5: {}
 
   fast-deep-equal@3.1.3: {}
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -583,7 +583,7 @@ ipcMain.handle('resolve-duplicates', async (_, resolution: {
       safeConsole.log(`🛡️ Skipped ${skippedStillReferenced} path(s) still referenced by kept tracks or duplicated in the delete list`);
     }
 
-    const deleteResults = { deleted: 0, failed: [] as { file: string; error: string }[] };
+    const deleteResults = { deleted: 0, trashed: [] as string[], failed: [] as { file: string; error: string }[] };
     if (resolution.deleteFromDisk && deletablePaths.length > 0) {
       for (const loc of deletablePaths) {
         try {
@@ -591,6 +591,7 @@ ipcMain.handle('resolve-duplicates', async (_, resolution: {
           // recoverable by the user instead of destroying audio permanently.
           await shell.trashItem(loc);
           deleteResults.deleted++;
+          deleteResults.trashed.push(loc);
           safeConsole.log(`🗑️ Moved to trash: ${loc}`);
         } catch (err) {
           const msg = err instanceof Error ? err.message : 'Unknown error';
@@ -605,6 +606,7 @@ ipcMain.handle('resolve-duplicates', async (_, resolution: {
       backupPath,
       tracksRemoved: tracksToRemove.length,
       filesDeleted: deleteResults.deleted,
+      trashedPaths: deleteResults.trashed,
       deleteErrors: deleteResults.failed,
       updatedLibrary: library
     };

--- a/src/renderer/AppWithRouter.tsx
+++ b/src/renderer/AppWithRouter.tsx
@@ -130,13 +130,14 @@ const AppWithRouter: React.FC = () => {
             showNotification,
             setLibraryData
           }}>
-            <AnimatePresence mode="wait">
+            {/* No mode="wait": the outgoing page's exit would otherwise have to
+                finish before the new one starts, doubling the perceived delay. */}
+            <AnimatePresence initial={false}>
               <motion.div
                 key={location.pathname}
-                initial={{ opacity: 0, x: 10 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -10 }}
-                transition={{ duration: 0.15, ease: 'easeInOut' }}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ duration: 0.09, ease: 'easeOut' }}
                 className="h-full"
               >
                 <div className="h-full flex flex-col">

--- a/src/renderer/AppWithRouter.tsx
+++ b/src/renderer/AppWithRouter.tsx
@@ -31,6 +31,7 @@ const pathToTab: Record<string, TabType> = {
   '/import': 'import',
   '/maintenance': 'maintenance',
   '/statistics': 'statistics',
+  '/history': 'history',
 };
 
 const AppWithRouter: React.FC = () => {

--- a/src/renderer/components/DuplicateDetector.tsx
+++ b/src/renderer/components/DuplicateDetector.tsx
@@ -410,103 +410,103 @@ const DuplicateDetector: React.FC = () => {
       {/* Content Area */}
       <div className="flex-1 flex flex-col overflow-hidden">
         {/* Actions Bar */}
-        <div className="flex-shrink-0 py-4 px-0 bg-te-grey-200 border-b-2 border-te-grey-300">
-          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-4 mx-4">
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              <PopoverButton
-                onClick={scanForDuplicates}
-                disabled={isScanning}
-                loading={isScanning}
-                icon={Search}
-                title="Scan for Duplicates"
-                description="Analyze your library to find duplicate tracks using advanced algorithms"
-                variant="primary"
-              >
-                {isScanning ? 'Scanning...' : 'Scan for Duplicates'}
-              </PopoverButton>
-
-              {/* Filter by what the duplicate actually is: real duplicate files on
-                disk, or several rekordbox entries for one file. */}
-            <div className="flex items-center gap-1 mr-2">
-              {([
-                ['all', `All (${duplicates.length})`],
-                ['files', `Duplicate files (${kindCounts.files})`],
-                ['entries', `Same-file entries (${kindCounts.entries})`],
-              ] as const).map(([value, label]) => (
-                <button
-                  key={value}
-                  onClick={() => setKindFilter(value)}
-                  className={`text-[11px] font-te-mono px-2 py-1 rounded-te border transition-colors normal-case ${
-                    kindFilter === value
-                      ? 'bg-te-orange text-te-cream border-te-orange'
-                      : 'bg-te-grey-100 text-te-grey-700 border-te-grey-300 hover:bg-te-grey-200'
-                  }`}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
+        <div className="flex-shrink-0 bg-te-grey-200 border-b-2 border-te-grey-300">
+          {/* Row 1 — the one thing you came here to do, plus finding your way
+              around the result. The search grows; nothing else competes. */}
+          <div className="flex items-center gap-3 px-4 pt-4">
             <PopoverButton
-                onClick={selectAllInMode}
-                disabled={duplicates.length === 0}
-                icon={CheckCircle2}
-                title="Select All Duplicates"
-                description="Select all duplicate sets for bulk resolution"
-                variant="secondary"
-              >
-                Select All ({visibleDuplicates.length})
-              </PopoverButton>
+              onClick={scanForDuplicates}
+              disabled={isScanning}
+              loading={isScanning}
+              icon={Search}
+              title="Scan for Duplicates"
+              description="Analyze your library to find duplicate tracks using advanced algorithms"
+              variant="primary"
+            >
+              {isScanning ? 'Scanning...' : 'Scan for Duplicates'}
+            </PopoverButton>
 
-              <PopoverButton
-                onClick={clearAll}
-                disabled={selectedDuplicates.size === 0}
-                icon={Trash2}
-                title="Clear Selection"
-                description="Deselect all currently selected duplicate sets"
-                variant="secondary"
-              >
-                Clear Selection ({selectedDuplicates.size})
-              </PopoverButton>
-            </div>
-
-            <div className="flex items-center space-x-3">
-              <input
-                type="text"
-                value={searchFilter}
-                onChange={(e) => setSearchFilter(e.target.value)}
-                placeholder="Search duplicates..."
-                className="input w-72"
-              />
-            </div>
+            <input
+              type="text"
+              value={searchFilter}
+              onChange={(e) => setSearchFilter(e.target.value)}
+              placeholder="Search duplicates..."
+              className="input flex-1 min-w-0"
+            />
           </div>
 
-          {/* Selection Controls */}
-          <div className="flex items-center justify-between mx-4">
-            <div className="flex items-center space-x-4">
-              {duplicates.length > 0 && (
-                <>
-                  <span className="te-value">
-                    {searchFilter ? `${filteredDuplicates.length} of ${duplicates.length} sets` : `${duplicates.length} sets`}
-                  </span>
-                  <span className="te-value">
-                    {selectedDuplicates.size} selected
-                  </span>
-                </>
-              )}
-            </div>
+          {/* Row 2 — which kind of duplicate you are looking at, and what you
+              do with that subset. One segmented control, never wrapping. */}
+          {duplicates.length > 0 && (
+            <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+              <div className="inline-flex rounded-te border border-te-grey-300 overflow-hidden">
+                {([
+                  ['all', 'All', duplicates.length,
+                    'Every duplicate set found'],
+                  ['files', 'Duplicate files', kindCounts.files,
+                    'Separate files on disk — resolving can move the extra files to the trash'],
+                  ['entries', 'Same-file entries', kindCounts.entries,
+                    'Several rekordbox entries for one file — resolving removes the extra entries, no file is touched'],
+                ] as const).map(([value, label, count, hint], i) => (
+                  <button
+                    key={value}
+                    onClick={() => setKindFilter(value)}
+                    title={hint}
+                    className={`px-3 py-1.5 text-xs font-te-mono whitespace-nowrap normal-case transition-colors ${
+                      i > 0 ? 'border-l border-te-grey-300' : ''
+                    } ${
+                      kindFilter === value
+                        ? 'bg-te-orange text-te-cream'
+                        : 'bg-te-grey-100 text-te-grey-700 hover:bg-te-grey-50'
+                    }`}
+                  >
+                    {label}
+                    <span className={`ml-1.5 tabular-nums ${kindFilter === value ? 'opacity-70' : 'text-te-grey-500'}`}>
+                      {count}
+                    </span>
+                  </button>
+                ))}
+              </div>
 
-            {duplicates.length > 0 && (
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={selectAllInMode}
+                  disabled={visibleDuplicates.length === 0}
+                  className="btn-ghost text-xs disabled:opacity-40"
+                >
+                  <CheckCircle2 className="w-3.5 h-3.5 inline mr-1.5" />
+                  Select all {visibleDuplicates.length}
+                </button>
+                <button
+                  onClick={clearAll}
+                  disabled={selectedDuplicates.size === 0}
+                  className="btn-ghost text-xs disabled:opacity-40"
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Row 3 — the destructive step. Hidden until something is selected,
+              so the resting toolbar has no armed delete control in it. The
+              counts live in the page header; repeating them here was noise. */}
+          {selectedDuplicates.size > 0 && (
+            <div className="flex flex-wrap items-center justify-end gap-3 mx-4 pb-4">
+              <span className="te-label text-xs normal-case mr-auto">
+                {selectedDuplicates.size} set{selectedDuplicates.size !== 1 ? 's' : ''} selected
+              </span>
               <div className="flex items-center gap-3">
-                <label className="flex items-center gap-1.5 cursor-pointer select-none" title="Permanently delete the losing duplicate files from disk after resolving">
+                <label className="flex items-center gap-1.5 cursor-pointer select-none" title="Move the duplicate files of the copies being merged to the system trash. A file the kept track still uses is never touched.">
                   <input
                     type="checkbox"
                     checked={deleteFromDisk}
                     onChange={e => setDeleteFromDisk(e.target.checked)}
                     className="checkbox"
                   />
-                  <span className="flex items-center gap-1 text-xs font-te-mono text-te-red-500">
+                  <span className="flex items-center gap-1 text-xs font-te-mono text-te-red-500 normal-case">
                     <AlertTriangle className="w-3 h-3" />
-                    Also delete files from disk
+                    Also move duplicate files to trash
                   </span>
                 </label>
                 <PopoverButton
@@ -521,8 +521,8 @@ const DuplicateDetector: React.FC = () => {
                   {isScanning ? 'Resolving...' : 'Resolve Selected'}
                 </PopoverButton>
               </div>
-            )}
-          </div>
+            </div>
+          )}
         </div>
 
         {/* Results List */}

--- a/src/renderer/components/DuplicateDetector.tsx
+++ b/src/renderer/components/DuplicateDetector.tsx
@@ -258,13 +258,21 @@ const DuplicateDetector: React.FC = () => {
         setDuplicates(remainingDuplicates);
         setSelections([]);
 
-        let msg = `✅ Resolved ${selectedDuplicates.size} duplicate sets — ${result.tracksRemoved} tracks removed from XML.\n📁 Backup: ${result.backupPath}`;
+        // Say what actually happened: duplicate entries are merged into the
+        // copy you keep and playlists follow it. "Removed from XML" read like
+        // music had been lost.
+        const sets = selectedDuplicates.size;
+        const merged = result.tracksRemoved;
+        let msg = `✅ Merged ${sets} duplicate set${sets !== 1 ? 's' : ''} — ${merged} extra entr${merged !== 1 ? 'ies' : 'y'} folded into the track you kept. Playlists now point at it.`;
         if (withDelete) {
-          msg += `\n🗑️ ${result.filesDeleted} file${result.filesDeleted !== 1 ? 's' : ''} deleted from disk`;
+          msg += result.filesDeleted > 0
+            ? `\n🗑️ ${result.filesDeleted} duplicate file${result.filesDeleted !== 1 ? 's' : ''} moved to the trash`
+            : '\n🗑️ No files needed removing — every copy pointed at the same file';
           if ((result.deleteErrors?.length ?? 0) > 0) {
-            msg += ` (${result.deleteErrors!.length} failed — check paths)`;
+            msg += ` (${result.deleteErrors!.length} could not be trashed — check paths)`;
           }
         }
+        msg += `\n📁 Library backup: ${result.backupPath}`;
         showNotification('success', msg);
 
         if (result.updatedLibrary && libraryData) {

--- a/src/renderer/components/DuplicateDetector.tsx
+++ b/src/renderer/components/DuplicateDetector.tsx
@@ -17,6 +17,7 @@ import { SettingsPanel } from './SettingsPanel';
 import { countPlaylistMembership } from '../utils/playlistMembership';
 import { pickRecommendedTrack } from '../utils/pickRecommendedTrack';
 import { upsertDuplicateSet } from '../utils/upsertDuplicateSet';
+import { duplicationHistoryStorage, type ActivityDetail } from '../db/duplicationHistoryDb';
 
 const DuplicateDetector: React.FC = () => {
   const { libraryData, libraryPath, showNotification, setLibraryData } = useAppContext();
@@ -274,6 +275,37 @@ const DuplicateDetector: React.FC = () => {
         }
         msg += `\n📁 Library backup: ${result.backupPath}`;
         showNotification('success', msg);
+
+        // Record what happened so the History tab can be used to verify it.
+        const details: ActivityDetail[] = [];
+        for (const set of selectedDuplicateSets as any[]) {
+          const keeper = pickRecommendedTrack(set.tracks, resolutionStrategy, set.pathPreferences);
+          for (const t of set.tracks) {
+            if (t.id === keeper?.id) { continue; }
+            details.push({
+              action: 'merged',
+              trackName: `${t.artist} - ${t.name}`,
+              from: t.location,
+              to: keeper?.location,
+            });
+          }
+        }
+        for (const trashed of (result.trashedPaths ?? [])) {
+          details.push({ action: 'trashed', from: trashed });
+        }
+        for (const failure of (result.deleteErrors ?? [])) {
+          details.push({ action: 'failed', from: failure.file, error: failure.error });
+        }
+        void duplicationHistoryStorage.record({
+          libraryPath,
+          timestamp: new Date(),
+          type: 'duplicate-merge',
+          summary: `Merged ${sets} duplicate set${sets !== 1 ? 's' : ''}`
+            + ` — ${merged} entr${merged !== 1 ? 'ies' : 'y'} folded in`
+            + (withDelete ? `, ${result.filesDeleted} file${result.filesDeleted !== 1 ? 's' : ''} to trash` : ''),
+          backupPath: result.backupPath,
+          details,
+        });
 
         if (result.updatedLibrary && libraryData) {
           setLibraryData({

--- a/src/renderer/components/DuplicateDetector.tsx
+++ b/src/renderer/components/DuplicateDetector.tsx
@@ -90,10 +90,10 @@ const DuplicateDetector: React.FC = () => {
             setDuplicates(stored.duplicates || []);
             setSelections(stored.selectedDuplicates || []);
             setHasScanned(stored.hasScanned || false);
-            // Merge stored scan options with current preferences
-            if (stored.scanOptions) {
-              setScanOptions({...scanOptions, ...stored.scanOptions});
-            }
+            // NOTE: scan options and the resolution strategy are NOT restored
+            // from this per-library cache. The persisted settings store is the
+            // single source of truth; restoring a stale snapshot here used to
+            // reset the user's chosen strategy back to the default.
           } else {
             // No stored results for this library, reset to default state
             setHasScanned(false);

--- a/src/renderer/components/DuplicateDetector.tsx
+++ b/src/renderer/components/DuplicateDetector.tsx
@@ -17,6 +17,7 @@ import { SettingsPanel } from './SettingsPanel';
 import { countPlaylistMembership } from '../utils/playlistMembership';
 import { pickRecommendedTrack } from '../utils/pickRecommendedTrack';
 import { upsertDuplicateSet } from '../utils/upsertDuplicateSet';
+import { classifyDuplicateSet } from '../utils/classifyDuplicateSet';
 import { duplicationHistoryStorage, type ActivityDetail } from '../db/duplicationHistoryDb';
 
 const DuplicateDetector: React.FC = () => {
@@ -54,6 +55,31 @@ const DuplicateDetector: React.FC = () => {
     isSearching,
     filteredDuplicates
   } = useDuplicates(libraryPath);
+
+  // "Duplicate" covers two unrelated jobs: real duplicate FILES on disk, and
+  // several rekordbox ENTRIES for one file. They are cleaned up separately.
+  const [kindFilter, setKindFilter] = useState<'all' | 'files' | 'entries'>('all');
+
+  const kindCounts = useMemo(() => {
+    let entries = 0, files = 0;
+    for (const d of duplicates as any[]) {
+      if (classifyDuplicateSet(d.tracks) === 'entries') { entries++; } else { files++; }
+    }
+    return { entries, files };
+  }, [duplicates]);
+
+  // The filter narrows the list; Select All follows it, so you can act on just
+  // the real duplicate files or just the same-file entries.
+  const visibleDuplicates = useMemo(() => {
+    if (kindFilter === 'all') { return filteredDuplicates as any[]; }
+    return (filteredDuplicates as any[]).filter(
+      (d) => (classifyDuplicateSet(d.tracks) === 'entries') === (kindFilter === 'entries')
+    );
+  }, [filteredDuplicates, kindFilter]);
+
+  const selectAllInMode = useCallback(() => {
+    setSelections(visibleDuplicates.map((d: any) => d.id));
+  }, [visibleDuplicates, setSelections]);
 
   console.log('🎯 DuplicateDetector render - duplicates:', { length: duplicates.length, hasScanned, isScanning });
 
@@ -368,7 +394,7 @@ const DuplicateDetector: React.FC = () => {
       <PageHeader
         title="Duplicate Detection"
         icon={Search}
-        stats={`${duplicates.length} sets found${wasCancelled ? ' (partial scan)' : ''} • ${selectedDuplicates.size} selected`}
+        stats={`${visibleDuplicates.length} of ${duplicates.length} sets${wasCancelled ? ' (partial scan)' : ''} • ${selectedDuplicates.size} selected`}
         actions={
           <PopoverButton
             onClick={() => setShowSettings(!showSettings)}
@@ -399,15 +425,36 @@ const DuplicateDetector: React.FC = () => {
                 {isScanning ? 'Scanning...' : 'Scan for Duplicates'}
               </PopoverButton>
 
-              <PopoverButton
-                onClick={selectAll}
+              {/* Filter by what the duplicate actually is: real duplicate files on
+                disk, or several rekordbox entries for one file. */}
+            <div className="flex items-center gap-1 mr-2">
+              {([
+                ['all', `All (${duplicates.length})`],
+                ['files', `Duplicate files (${kindCounts.files})`],
+                ['entries', `Same-file entries (${kindCounts.entries})`],
+              ] as const).map(([value, label]) => (
+                <button
+                  key={value}
+                  onClick={() => setKindFilter(value)}
+                  className={`text-[11px] font-te-mono px-2 py-1 rounded-te border transition-colors normal-case ${
+                    kindFilter === value
+                      ? 'bg-te-orange text-te-cream border-te-orange'
+                      : 'bg-te-grey-100 text-te-grey-700 border-te-grey-300 hover:bg-te-grey-200'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <PopoverButton
+                onClick={selectAllInMode}
                 disabled={duplicates.length === 0}
                 icon={CheckCircle2}
                 title="Select All Duplicates"
                 description="Select all duplicate sets for bulk resolution"
                 variant="secondary"
               >
-                Select All ({duplicates.length})
+                Select All ({visibleDuplicates.length})
               </PopoverButton>
 
               <PopoverButton
@@ -493,7 +540,7 @@ const DuplicateDetector: React.FC = () => {
             </div>
             <div className="relative">
               <VirtualizedDuplicateList
-                duplicates={filteredDuplicates}
+                duplicates={visibleDuplicates}
                 selectedDuplicates={selectedDuplicates}
                 onToggleSelection={toggleDuplicateSelection}
                 resolutionStrategy={resolutionStrategy}

--- a/src/renderer/components/DuplicateItem.tsx
+++ b/src/renderer/components/DuplicateItem.tsx
@@ -15,6 +15,7 @@ import { useFileOperations } from '../hooks';
 import { ConfidenceBadge, PlayButton } from './ui';
 import { useSettingsStore } from '../stores/settingsStore';
 import { pickRecommendedTrack } from '../utils/pickRecommendedTrack';
+import { classifyDuplicateSet, deletableFileCount } from '../utils/classifyDuplicateSet';
 
 const _ext = (loc: string) => '.' + ((loc || '').split('.').pop()?.toLowerCase() ?? '');
 const isUniversalLossless = (loc: string) => ['.wav', '.aiff', '.aif'].includes(_ext(loc));
@@ -58,6 +59,20 @@ const DuplicateItem: React.FC<DuplicateItemProps> = memo(({
     }
     return { count: names.size, names: Array.from(names) };
   }, [duplicate.tracks, playlistMembership]);
+
+  // Two very different situations wear the word "duplicate": several rekordbox
+  // entries for ONE file (nothing to delete) versus genuinely duplicated files.
+  const kind = useMemo(() => classifyDuplicateSet(duplicate.tracks), [duplicate.tracks]);
+  const filesToRemove = useMemo(
+    () => deletableFileCount(duplicate.tracks, recommendedTrack?.id),
+    [duplicate.tracks, recommendedTrack]
+  );
+
+  const kindBadge = {
+    entries: { label: 'Same file · duplicate entries', className: 'bg-te-grey-200 text-te-grey-700 border-te-grey-300' },
+    files: { label: 'Duplicate files', className: 'bg-te-amber-100 text-te-amber-600 border-te-amber-200' },
+    mixed: { label: 'Mixed · some share a file', className: 'bg-te-amber-100 text-te-amber-600 border-te-amber-200' },
+  }[kind];
 
   const toggleExpanded = useCallback(() => {
     setIsExpanded(prev => !prev);
@@ -106,6 +121,15 @@ const DuplicateItem: React.FC<DuplicateItemProps> = memo(({
               <span className="text-xs text-zinc-400">•</span>
               <span className="text-xs text-zinc-400 capitalize">
                 {duplicate.matchType} match
+              </span>
+              <span className="text-xs text-zinc-400">•</span>
+              <span
+                className={`text-[10px] font-te-mono px-1.5 py-0.5 rounded-te border normal-case ${kindBadge.className}`}
+                title={kind === 'entries'
+                  ? 'Every copy points at the same file on disk — resolving removes the extra entries only.'
+                  : `Resolving can move ${filesToRemove} file${filesToRemove !== 1 ? 's' : ''} to the trash.`}
+              >
+                {kindBadge.label}
               </span>
               <span className="text-xs text-zinc-400">•</span>
               <span

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -81,12 +81,23 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     }, 500); // 500ms debounce
   }, [setScanOptions, setResolutionStrategy]);
 
-  // Sync changes with debounce
+  // Sync changes with debounce.
+  // Skipped on mount: the panel is always mounted (the slideout only slides it
+  // off-screen), so writing the form's initial values back would overwrite the
+  // persisted settings with whatever the form captured at first render.
+  const hasUserEdited = useRef(false);
   useEffect(() => {
+    if (!hasUserEdited.current) { hasUserEdited.current = true; return; }
     if (watchedScanOptions && watchedResolutionStrategy) {
       syncToStore(watchedScanOptions, watchedResolutionStrategy);
     }
   }, [watchedScanOptions, watchedResolutionStrategy, syncToStore]);
+
+  // The form's defaultValues are captured once; re-apply the stored settings
+  // whenever they change so the panel never shows or re-saves a stale strategy.
+  useEffect(() => {
+    setValue('resolutionStrategy', resolutionStrategy);
+  }, [resolutionStrategy, setValue]);
 
   // Cleanup debounce on unmount
   useEffect(() => {

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
     BarChart2,
     Wrench,
     Copy,
+    History,
     FolderOpen,
     X,
     HelpCircle
@@ -48,6 +49,13 @@ const navItems = [
         label: 'Statistics',
         icon: BarChart2,
         description: 'Get insights for your library'
+    },
+    {
+        id: 'history' as TabType,
+        path: '/history',
+        label: 'History',
+        icon: History,
+        description: 'What the app changed in your library'
     }
 ];
 

--- a/src/renderer/components/TrackRelocator.tsx
+++ b/src/renderer/components/TrackRelocator.tsx
@@ -12,7 +12,6 @@ import {
   Zap,
   Target,
   FileSearch,
-  History
 } from 'lucide-react';
 import { useTrackRelocator } from '../hooks/useTrackRelocator';
 import { useSettingsStore } from '../stores/settingsStore';
@@ -25,7 +24,6 @@ import { AutoRelocateProgressDialog } from './ui/AutoRelocateProgressDialog';
 import { TrackRelocatorSettings } from './TrackRelocatorSettings';
 import { VirtualizedList } from './VirtualizedList';
 import { MissingTrackItem } from './MissingTrackItem';
-import { RelocationHistoryPanel } from './RelocationHistoryPanel';
 
 const TrackRelocator: React.FC = () => {
   const { libraryData, libraryPath, showNotification, setLibraryData } = useAppContext();
@@ -62,7 +60,6 @@ const TrackRelocator: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedMissingTracks, setSelectedMissingTracks] = useState<Set<string>>(new Set());
   const [showSettings, setShowSettings] = useState(false);
-  const [showHistory, setShowHistory] = useState(false);
   const [newSearchPath, setNewSearchPath] = useState('');
   const [isResetting, setIsResetting] = useState(false);
   const [isAutoRelocating, setIsAutoRelocating] = useState(false);
@@ -216,14 +213,6 @@ const TrackRelocator: React.FC = () => {
         stats={`${stats.totalMissingTracks} missing • ${stats.configuredRelocations} configured • ${selectedMissingTracks.size} selected`}
         actions={
           <>
-            <PopoverButton
-              onClick={() => setShowHistory(!showHistory)}
-              icon={History}
-              title="Relocation History"
-              description="View log of all successful track relocations with timestamps and details"
-            >
-              History
-            </PopoverButton>
             <PopoverButton
               onClick={() => setShowSettings(!showSettings)}
               icon={Settings}
@@ -501,20 +490,6 @@ const TrackRelocator: React.FC = () => {
           setNewSearchPath={setNewSearchPath}
           addSearchPath={addSearchPath}
           removeSearchPath={removeSearchPath}
-        />
-      </SettingsSlideout>
-
-      {/* History Slideout */}
-      <SettingsSlideout
-        isOpen={showHistory}
-        onClose={() => setShowHistory(false)}
-        title="RELOCATION HISTORY"
-        subtitle="Log of successful track relocations"
-        width="xl"
-      >
-        <RelocationHistoryPanel
-          libraryPath={libraryData?.libraryPath || null}
-          onShowFileInFolder={showInFolder}
         />
       </SettingsSlideout>
 

--- a/src/renderer/components/pages/HistoryPage.tsx
+++ b/src/renderer/components/pages/HistoryPage.tsx
@@ -40,6 +40,11 @@ export const HistoryPage: React.FC = () => {
     if (p === libraryPath) { load(); }
   }), [libraryPath, load]);
 
+  const presentTypes = useMemo(
+    () => Array.from(new Set(entries.map((e) => e.type))),
+    [entries]
+  );
+
   const visible = useMemo(() => {
     const needle = search.trim().toLowerCase();
     return entries.filter((e) => {
@@ -81,8 +86,9 @@ export const HistoryPage: React.FC = () => {
           className="input text-xs py-1"
         >
           <option value="all">All operations</option>
-          {Object.entries(TYPE_META).map(([value, meta]) => (
-            <option key={value} value={value}>{meta.label}</option>
+          {/* Only offer types that actually occur — an empty filter is a dead end. */}
+          {presentTypes.map((value) => (
+            <option key={value} value={value}>{TYPE_META[value]?.label ?? value}</option>
           ))}
         </select>
         <input

--- a/src/renderer/components/pages/HistoryPage.tsx
+++ b/src/renderer/components/pages/HistoryPage.tsx
@@ -1,0 +1,176 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronRight, ChevronDown, FolderOpen, Trash2, AlertTriangle, Layers, Move, Copy, Save, History as HistoryIcon } from 'lucide-react';
+import { useAppContext } from '../../AppWithRouter';
+import { PageHeader } from '../ui';
+import {
+  duplicationHistoryStorage,
+  duplicationHistoryEvents,
+  type ActivityEntry,
+} from '../../db/duplicationHistoryDb';
+
+const TYPE_META: Record<ActivityEntry['type'], { label: string; Icon: typeof Layers }> = {
+  'duplicate-merge': { label: 'Duplicates', Icon: Layers },
+  relocation: { label: 'Relocation', Icon: Move },
+  consolidate: { label: 'Consolidate', Icon: Copy },
+  'filter-move': { label: 'Filter copy/move', Icon: Copy },
+  'xml-save': { label: 'Library saved', Icon: Save },
+};
+
+const formatTime = (value: Date | string) => {
+  const d = value instanceof Date ? value : new Date(value);
+  return d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit',
+  });
+};
+
+export const HistoryPage: React.FC = () => {
+  const { libraryPath } = useAppContext();
+  const [entries, setEntries] = useState<ActivityEntry[]>([]);
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const [typeFilter, setTypeFilter] = useState<'all' | ActivityEntry['type']>('all');
+  const [search, setSearch] = useState('');
+
+  const load = useCallback(async () => {
+    if (!libraryPath) { setEntries([]); return; }
+    setEntries(await duplicationHistoryStorage.list(libraryPath));
+  }, [libraryPath]);
+
+  useEffect(() => { load(); }, [load]);
+  useEffect(() => duplicationHistoryEvents.onUpdate((p) => {
+    if (p === libraryPath) { load(); }
+  }), [libraryPath, load]);
+
+  const visible = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return entries.filter((e) => {
+      if (typeFilter !== 'all' && e.type !== typeFilter) { return false; }
+      if (!needle) { return true; }
+      if (e.summary.toLowerCase().includes(needle)) { return true; }
+      return e.details.some((d) =>
+        [d.trackName, d.from, d.to, d.error].some((v) => v?.toLowerCase().includes(needle)));
+    });
+  }, [entries, typeFilter, search]);
+
+  const toggle = (id: number) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) { next.delete(id); } else { next.add(id); }
+      return next;
+    });
+  };
+
+  const reveal = async (path: string) => {
+    try { await window.electronAPI.showFileInFolder(path); } catch { /* nothing to do */ }
+  };
+
+  const failureCount = (entry: ActivityEntry) =>
+    entry.details.filter((d) => d.action === 'failed').length;
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <PageHeader
+        icon={HistoryIcon}
+        title="History"
+        stats={`${entries.length} operation${entries.length !== 1 ? 's' : ''} recorded`}
+      />
+
+      <div className="px-4 py-3 flex flex-wrap items-center gap-2 border-b border-te-grey-300">
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value as any)}
+          className="input text-xs py-1"
+        >
+          <option value="all">All operations</option>
+          {Object.entries(TYPE_META).map(([value, meta]) => (
+            <option key={value} value={value}>{meta.label}</option>
+          ))}
+        </select>
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search track or path..."
+          className="input text-xs py-1 flex-1 min-w-[200px]"
+        />
+        {entries.length > 0 && (
+          <button
+            onClick={async () => { await duplicationHistoryStorage.clear(libraryPath); load(); }}
+            className="btn-ghost text-xs"
+          >
+            <Trash2 size={12} className="inline mr-1" /> Clear
+          </button>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 space-y-2">
+        {!libraryPath ? (
+          <p className="te-label text-center mt-10 normal-case">Load a library to see its history.</p>
+        ) : visible.length === 0 ? (
+          <p className="te-label text-center mt-10 normal-case">
+            {entries.length === 0
+              ? 'Nothing recorded yet. Operations that change your library will appear here.'
+              : 'No operations match this filter.'}
+          </p>
+        ) : (
+          visible.map((entry) => {
+            const meta = TYPE_META[entry.type];
+            const Icon = meta?.Icon ?? Layers;
+            const isOpen = expanded.has(entry.id!);
+            const failures = failureCount(entry);
+            return (
+              <div key={entry.id} className="card p-3">
+                <button
+                  onClick={() => toggle(entry.id!)}
+                  className="w-full flex items-start gap-2 text-left"
+                >
+                  {isOpen ? <ChevronDown size={14} className="mt-1 flex-shrink-0" />
+                    : <ChevronRight size={14} className="mt-1 flex-shrink-0" />}
+                  <Icon size={14} className="mt-1 flex-shrink-0 text-te-orange" />
+                  <span className="flex-1 min-w-0">
+                    <span className="te-value text-sm block">{entry.summary}</span>
+                    <span className="te-label text-xs normal-case">
+                      {formatTime(entry.timestamp)} • {meta?.label ?? entry.type}
+                      {failures > 0 && (
+                        <span className="text-te-red-500 ml-2">
+                          <AlertTriangle size={11} className="inline mr-0.5" />
+                          {failures} failed
+                        </span>
+                      )}
+                    </span>
+                  </span>
+                </button>
+
+                {isOpen && (
+                  <div className="mt-2 ml-6 space-y-1">
+                    {entry.backupPath && (
+                      <button
+                        onClick={() => reveal(entry.backupPath!)}
+                        className="text-xs text-te-orange hover:underline flex items-center gap-1"
+                      >
+                        <FolderOpen size={11} /> Reveal backup
+                      </button>
+                    )}
+                    {entry.details.map((d, i) => (
+                      <div
+                        key={i}
+                        className={`te-path text-xs ${d.action === 'failed' ? 'text-te-red-500' : 'text-te-grey-600'}`}
+                      >
+                        <span className="uppercase mr-2">{d.action}</span>
+                        {d.trackName && <span className="te-value mr-2">{d.trackName}</span>}
+                        {d.from && <span>{d.from}</span>}
+                        {d.to && <span> → {d.to}</span>}
+                        {d.error && <span> — {d.error}</span>}
+                      </div>
+                    ))}
+                    {entry.details.length === 0 && (
+                      <p className="te-label text-xs normal-case">No item-level detail recorded.</p>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/db/duplicationHistoryDb.ts
+++ b/src/renderer/db/duplicationHistoryDb.ts
@@ -1,0 +1,108 @@
+import Dexie, { type EntityTable } from 'dexie';
+
+/** One line of detail inside an operation — what happened to a single item. */
+export interface ActivityDetail {
+  action: 'merged' | 'trashed' | 'relocated' | 'copied' | 'moved' | 'failed';
+  trackName?: string;
+  from?: string;
+  to?: string;
+  error?: string;
+}
+
+/** One library-changing operation, with its per-item detail lines. */
+export interface ActivityEntry {
+  id?: number;
+  libraryPath: string;
+  timestamp: Date;
+  type: 'duplicate-merge' | 'relocation' | 'consolidate' | 'filter-move' | 'xml-save';
+  summary: string;
+  backupPath?: string;
+  details: ActivityDetail[];
+}
+
+/** Keep the log useful without letting it grow without bound. */
+export const MAX_ENTRIES_PER_LIBRARY = 500;
+
+class DuplicationHistoryDatabase extends Dexie {
+  activity!: EntityTable<ActivityEntry, 'id'>;
+
+  constructor() {
+    super('RekordboxDuplicationHistoryDB');
+    this.version(1).stores({
+      activity: '++id, libraryPath, timestamp, type',
+    });
+  }
+}
+
+let db: DuplicationHistoryDatabase | null = null;
+function getDb(): DuplicationHistoryDatabase {
+  if (!db) { db = new DuplicationHistoryDatabase(); }
+  return db;
+}
+
+const listeners: ((libraryPath: string) => void)[] = [];
+
+export const duplicationHistoryEvents = {
+  onUpdate(callback: (libraryPath: string) => void) {
+    listeners.push(callback);
+    return () => {
+      const i = listeners.indexOf(callback);
+      if (i > -1) { listeners.splice(i, 1); }
+    };
+  },
+  notify(libraryPath: string) {
+    listeners.forEach((cb) => cb(libraryPath));
+  },
+};
+
+export const duplicationHistoryStorage = {
+  /** Record one operation. Never throws: logging must not break the action. */
+  async record(entry: Omit<ActivityEntry, 'id'>): Promise<void> {
+    try {
+      const database = getDb();
+      await database.activity.add(entry as ActivityEntry);
+      await this.prune(entry.libraryPath);
+      duplicationHistoryEvents.notify(entry.libraryPath);
+    } catch (error) {
+      console.error('Failed to record activity:', error);
+    }
+  },
+
+  /** Newest first. */
+  async list(libraryPath: string, limit = MAX_ENTRIES_PER_LIBRARY): Promise<ActivityEntry[]> {
+    try {
+      const entries = await getDb().activity.where('libraryPath').equals(libraryPath).toArray();
+      return entries
+        .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+        .slice(0, limit);
+    } catch (error) {
+      console.error('Failed to read activity history:', error);
+      return [];
+    }
+  },
+
+  /** Drop the oldest entries beyond MAX_ENTRIES_PER_LIBRARY. */
+  async prune(libraryPath: string): Promise<void> {
+    try {
+      const entries = await getDb().activity.where('libraryPath').equals(libraryPath).toArray();
+      if (entries.length <= MAX_ENTRIES_PER_LIBRARY) { return; }
+      const excess = entries
+        .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+        .slice(0, entries.length - MAX_ENTRIES_PER_LIBRARY)
+        .map((e) => e.id!)
+        .filter((id) => id !== undefined);
+      await getDb().activity.bulkDelete(excess);
+    } catch (error) {
+      console.error('Failed to prune activity history:', error);
+    }
+  },
+
+  async clear(libraryPath: string): Promise<void> {
+    try {
+      await getDb().activity.where('libraryPath').equals(libraryPath).delete();
+      duplicationHistoryEvents.notify(libraryPath);
+    } catch (error) {
+      console.error('Failed to clear activity history:', error);
+    }
+  },
+};

--- a/src/renderer/hooks/useRouteData.ts
+++ b/src/renderer/hooks/useRouteData.ts
@@ -7,38 +7,30 @@ import { relocationStorage } from '../db/relocationsDb';
  * Uses Dexie's useLiveQuery for reactive data
  */
 export function useRouteData(route: string, libraryPath?: string) {
-  // Get settings from Zustand - currently unused, commented for performance
-  // const settings = useSettingsStore();
+  const wantsDuplicates = route === '/' && !!libraryPath;
+  const wantsRelocations = route === '/relocate' && !!libraryPath;
 
-  // Fetch cached duplicate results
+  // Each query depends only on whether ITS route is active. Keying on the raw
+  // route made both queries re-run on every navigation, and a pending
+  // useLiveQuery is `undefined` — which used to flip isLoading and replace the
+  // page with a skeleton on every tab switch, re-reading the whole duplicate
+  // cache even for tabs that never use it.
   const duplicateResults = useLiveQuery(
-    async () => {
-      if (route === '/' && libraryPath) {
-        return await duplicateStorage.getDuplicateResult(libraryPath);
-      }
-      return null;
-    },
-    [route, libraryPath]
+    async () => (wantsDuplicates ? await duplicateStorage.getDuplicateResult(libraryPath!) : null),
+    [wantsDuplicates, libraryPath]
   );
 
-  // Fetch cached relocation results
   const relocationResults = useLiveQuery(
-    async () => {
-      if (route === '/relocate' && libraryPath) {
-        return await relocationStorage.getRelocationResult(libraryPath);
-      }
-      return null;
-    },
-    [route, libraryPath]
+    async () => (wantsRelocations ? await relocationStorage.getRelocationResult(libraryPath!) : null),
+    [wantsRelocations, libraryPath]
   );
 
-  // Return loading state and data
-  return {
-    isLoading: duplicateResults === undefined || relocationResults === undefined,
-    duplicateResults,
-    relocationResults
-    // settings // Commented out for performance - currently unused
-  };
+  // Only the data this route actually needs may hold up rendering.
+  const isLoading =
+    (wantsDuplicates && duplicateResults === undefined) ||
+    (wantsRelocations && relocationResults === undefined);
+
+  return { isLoading, duplicateResults, relocationResults };
 }
 
 /**

--- a/src/renderer/hooks/useTrackRelocator.ts
+++ b/src/renderer/hooks/useTrackRelocator.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo, useEffect } from 'react';
 import { relocationStorage, cloudSyncStorage, ownershipStorage } from '../db/relocationsDb';
 import { historyStorage, historyEvents } from '../db/historyDb';
+import { duplicationHistoryStorage } from '../db/duplicationHistoryDb';
 import type {
   MissingTrack,
   RelocationCandidate,
@@ -321,6 +322,21 @@ export function useTrackRelocator(
         const successfulTrackIds = result.data
           .filter((r: RelocationResult) => r.success)
           .map((r: RelocationResult) => r.trackId);
+
+        // Record in the activity history so the History tab shows relocations too.
+        void duplicationHistoryStorage.record({
+          libraryPath: effectiveLibraryPath,
+          timestamp: new Date(),
+          type: 'relocation',
+          summary: `Relocated ${successfulTrackIds.length} of ${result.data.length} track${result.data.length !== 1 ? 's' : ''}`,
+          backupPath: result.backupPath,
+          details: result.data.map((r: RelocationResult) => ({
+            action: r.success ? ('relocated' as const) : ('failed' as const),
+            from: r.oldLocation,
+            to: r.newLocation,
+            error: r.error,
+          })),
+        });
 
         // Update the main library data with new track locations
         if (libraryData && result.xmlUpdated) {

--- a/src/renderer/routes.tsx
+++ b/src/renderer/routes.tsx
@@ -5,6 +5,7 @@ import { RelocatePage } from './components/pages/RelocatePage';
 import { ImportPage } from './components/pages/ImportPage';
 import { MaintenancePage } from './components/pages/MaintenancePage';
 import { StatisticsPage } from './components/pages/StatisticsPage';
+import { HistoryPage } from './components/pages/HistoryPage';
 
 // Root route - wraps entire app
 export const rootRoute = createRootRoute({
@@ -42,6 +43,12 @@ export const statisticsRoute = createRoute({
   component: StatisticsPage,
 });
 
+export const historyRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/history',
+  component: HistoryPage,
+});
+
 // Create the route tree
 const routeTree = rootRoute.addChildren([
   duplicatesRoute,
@@ -49,6 +56,7 @@ const routeTree = rootRoute.addChildren([
   importRoute,
   maintenanceRoute,
   statisticsRoute,
+  historyRoute,
 ]);
 
 // Use memory history so file:// protocol in packaged Electron doesn't break routing

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -1,6 +1,6 @@
 // Global types and interfaces
 
-export type TabType = 'duplicates' | 'import' | 'relocate' | 'maintenance' | 'statistics';
+export type TabType = 'duplicates' | 'import' | 'relocate' | 'maintenance' | 'statistics' | 'history';
 
 export type NotificationType = 'success' | 'error' | 'info';
 

--- a/src/renderer/utils/classifyDuplicateSet.ts
+++ b/src/renderer/utils/classifyDuplicateSet.ts
@@ -1,0 +1,40 @@
+export type DuplicateKind = 'entries' | 'files' | 'mixed';
+
+/**
+ * Tell apart the two very different things a "duplicate" can be:
+ *
+ * - 'entries'  — every copy points at the SAME file on disk. Rekordbox simply
+ *                lists the song twice; there is nothing to delete. Resolving
+ *                collapses the extra entries and keeps the one file.
+ * - 'files'    — the copies point at different files. Resolving keeps one and
+ *                the others can be moved to the trash.
+ * - 'mixed'    — some copies share a file, others don't (both of the above).
+ *
+ * Comparison is case-insensitive: macOS and Windows filesystems are.
+ */
+export function classifyDuplicateSet(tracks: Array<{ location?: string }>): DuplicateKind {
+  const paths = tracks
+    .map((t) => (t.location ?? '').toLowerCase())
+    .filter((p) => p.length > 0);
+  if (paths.length === 0) { return 'entries'; }
+
+  const unique = new Set(paths);
+  if (unique.size === 1) { return 'entries'; }
+  if (unique.size === paths.length) { return 'files'; }
+  return 'mixed';
+}
+
+/** How many files this set would actually remove from disk. */
+export function deletableFileCount(
+  tracks: Array<{ id: string; location?: string }>,
+  keptTrackId?: string
+): number {
+  const keptLocation = (tracks.find((t) => t.id === keptTrackId)?.location ?? '').toLowerCase();
+  const others = new Set(
+    tracks
+      .filter((t) => t.id !== keptTrackId)
+      .map((t) => (t.location ?? '').toLowerCase())
+      .filter((p) => p.length > 0 && p !== keptLocation)
+  );
+  return others.size;
+}

--- a/tests/unit/classify-duplicate-set.test.ts
+++ b/tests/unit/classify-duplicate-set.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { classifyDuplicateSet, deletableFileCount } from '../../src/renderer/utils/classifyDuplicateSet';
+
+describe('classifyDuplicateSet', () => {
+  it('calls it entries when every copy points at the same file', () => {
+    expect(classifyDuplicateSet([
+      { location: '/m/song.mp3' },
+      { location: '/m/song.mp3' },
+    ])).toBe('entries');
+  });
+
+  it('ignores case differences when comparing paths', () => {
+    expect(classifyDuplicateSet([
+      { location: '/m/Song.mp3' },
+      { location: '/M/song.MP3' },
+    ])).toBe('entries');
+  });
+
+  it('calls it files when the copies are distinct files', () => {
+    expect(classifyDuplicateSet([
+      { location: '/m/a.mp3' },
+      { location: '/other/a.mp3' },
+    ])).toBe('files');
+  });
+
+  it('calls it mixed when some copies share a file and others do not', () => {
+    expect(classifyDuplicateSet([
+      { location: '/m/a.mp3' },
+      { location: '/m/a.mp3' },
+      { location: '/other/a.mp3' },
+    ])).toBe('mixed');
+  });
+
+  it('treats a set without locations as entries', () => {
+    expect(classifyDuplicateSet([{}, {}])).toBe('entries');
+  });
+});
+
+describe('deletableFileCount', () => {
+  it('is zero when the other copies are the same file as the kept one', () => {
+    const tracks = [
+      { id: 'a', location: '/m/song.mp3' },
+      { id: 'b', location: '/m/song.mp3' },
+    ];
+    expect(deletableFileCount(tracks, 'a')).toBe(0);
+  });
+
+  it('counts each distinct other file once', () => {
+    const tracks = [
+      { id: 'a', location: '/m/keep.mp3' },
+      { id: 'b', location: '/m/dup1.mp3' },
+      { id: 'c', location: '/m/dup1.mp3' },
+      { id: 'd', location: '/m/dup2.mp3' },
+    ];
+    expect(deletableFileCount(tracks, 'a')).toBe(2);
+  });
+});

--- a/tests/unit/duplication-history-db.test.ts
+++ b/tests/unit/duplication-history-db.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import { duplicationHistoryStorage, type ActivityEntry } from '../../src/renderer/db/duplicationHistoryDb';
+
+const LIB = '/lib/newlib.xml';
+
+const entry = (over: Partial<ActivityEntry> = {}): Omit<ActivityEntry, 'id'> => ({
+  libraryPath: LIB,
+  timestamp: new Date('2026-01-01T10:00:00Z'),
+  type: 'duplicate-merge',
+  summary: 'Merged 1 set',
+  details: [{ action: 'merged', trackName: 'Song' }],
+  ...over,
+});
+
+beforeEach(async () => {
+  await duplicationHistoryStorage.clear(LIB);
+  await duplicationHistoryStorage.clear('/other.xml');
+});
+
+describe('duplicationHistoryStorage', () => {
+  it('records an operation and reads it back with its details', async () => {
+    await duplicationHistoryStorage.record(entry({
+      summary: 'Merged 2 sets, 1 file to trash',
+      backupPath: '/lib/newlib.xml.backup.1',
+      details: [
+        { action: 'merged', trackName: 'A' },
+        { action: 'trashed', from: '/music/dup.mp3' },
+      ],
+    }));
+
+    const list = await duplicationHistoryStorage.list(LIB);
+    expect(list).toHaveLength(1);
+    expect(list[0].summary).toBe('Merged 2 sets, 1 file to trash');
+    expect(list[0].backupPath).toBe('/lib/newlib.xml.backup.1');
+    expect(list[0].details).toHaveLength(2);
+    expect(list[0].details[1]).toMatchObject({ action: 'trashed', from: '/music/dup.mp3' });
+  });
+
+  it('returns newest first', async () => {
+    await duplicationHistoryStorage.record(entry({ summary: 'old', timestamp: new Date('2026-01-01T10:00:00Z') }));
+    await duplicationHistoryStorage.record(entry({ summary: 'new', timestamp: new Date('2026-01-02T10:00:00Z') }));
+    const list = await duplicationHistoryStorage.list(LIB);
+    expect(list.map((e) => e.summary)).toEqual(['new', 'old']);
+  });
+
+  it('keeps libraries separate', async () => {
+    await duplicationHistoryStorage.record(entry({ summary: 'mine' }));
+    await duplicationHistoryStorage.record(entry({ libraryPath: '/other.xml', summary: 'theirs' }));
+    const list = await duplicationHistoryStorage.list(LIB);
+    expect(list.map((e) => e.summary)).toEqual(['mine']);
+  });
+
+  it('records failures so a bad operation is visible', async () => {
+    await duplicationHistoryStorage.record(entry({
+      summary: 'Merged 1 set, 1 file could not be trashed',
+      details: [{ action: 'failed', from: '/music/locked.mp3', error: 'EPERM' }],
+    }));
+    const [row] = await duplicationHistoryStorage.list(LIB);
+    expect(row.details[0]).toMatchObject({ action: 'failed', error: 'EPERM' });
+  });
+
+  it('clear removes only that library history', async () => {
+    await duplicationHistoryStorage.record(entry());
+    await duplicationHistoryStorage.record(entry({ libraryPath: '/other.xml' }));
+    await duplicationHistoryStorage.clear(LIB);
+    expect(await duplicationHistoryStorage.list(LIB)).toHaveLength(0);
+    expect(await duplicationHistoryStorage.list('/other.xml')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## History tab

A separate `duplicationHistoryDb` (its own Dexie database, leaving the existing relocation history untouched) records one entry per library-changing operation: a summary plus per-item detail — which entries were merged into which track, which files went to the trash, which failed and why — with the backup path.

The tab lists operations newest-first, filterable by type and searchable by track or path; a row expands to the exact items, failures in red, backup revealable in Finder. Kept to 500 operations per library. The relocator's own History button is gone: relocations are recorded here too, so there is one place to verify what the app changed. The type filter offers only types that actually occur.

## Duplicate files vs duplicate entries

Two unrelated situations both wore the word "duplicate": genuinely duplicated **files** on disk, and several rekordbox **entries** pointing at one file (where nothing can be deleted — the case that used to delete the kept file). `classifyDuplicateSet` labels each set, a badge on the row says which it is, and a toolbar filter narrows the list to one kind. Select All follows the filter, so either kind can be cleaned up on its own.

## Toolbar redesign

Four controls were crammed into a three-column grid, so the filter wrapped over three lines, and a stats line repeated the page header. Now three rows: scan + growing search; a segmented filter that never wraps with selection actions opposite; and the destructive step, which appears only once something is selected. The trash toggle's copy matches what it does.

## Fixes

- **Navigation was slow**: `useRouteData` keyed both Dexie queries on the raw route, so every tab switch re-ran both. A pending `useLiveQuery` is `undefined`, which flipped `isLoading`, replaced the page with a skeleton and re-deserialised the whole duplicate cache — even for tabs that never use it. Each query now depends only on its own route, and the transition no longer uses `mode="wait"`.
- **Resolution strategy reset to keep-highest-quality**: the always-mounted SettingsPanel wrote its captured form defaults back to the store on mount, and the per-library Dexie snapshot overwrote the persisted settings on load. The settings store is now the single source of truth.
- **Wording**: "1 tracks removed from XML" read as if music had been lost. It now says the entries were merged into the track you kept and that playlists follow it.

## Test plan

- 223 unit tests green (28 files); `pnpm build` clean.
- Exercised in the running app against a 5,644-track library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a History page showing library changes, searchable and filterable by operation type.
  - Added history for duplicate resolutions and track relocations, including failures, backups, and details.
  - Added duplicate-set classification for entries, files, and mixed results, with filtering and tailored bulk selection.
  - Added clear labels explaining whether resolution removes entries or moves files to trash.
  - Added History navigation and improved page transitions.

- **Bug Fixes**
  - Prevented settings from being overwritten during initial loading.
  - Improved route-specific loading and refreshed resolution strategy synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->