### PR TITLE
feat: rekordbox database import, backups, broken-entry cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## [0.5.0] - 2026-08-21
+
+### 🎉 New Features
+- **Read the rekordbox database directly**: Load a library from rekordbox's own encrypted `master.db`, no XML export needed. Opened strictly read-only from a copy (including its WAL), so rekordbox can stay open and the database is never written to. Needs the SQLCipher key, pasted once in Settings; the key is not shipped with the app.
+- **Duplicate files vs duplicate entries**: Every duplicate set now states the real numbers, for example `4 entries · 2 files`, and each entry says whether it is an extra listing of the kept file or a separate copy that the trash option can remove. A filter narrows the list to one kind, and Select All follows it.
+- **In-app help**: A "How duplicate resolving works" section explains entries versus files, what merging does to playlists, and what each label means.
+
+### 🐛 Bug Fixes
+- **Never write over master.db**: Loading from the database set the library path to `master.db`, while resolve and relocate write XML to that path — which would have destroyed the database. Every write path now refuses a `.db` path, and a banner marks a database-backed library as read-only.
+- **Unicode paths compared correctly**: macOS stores accents composed (ö) or decomposed (o + combining diaeresis) and treats both as one file; rekordbox libraries contain both spellings. Paths are now normalised before comparison. Previously a single file looked like two, and the delete guard could have trashed the file the kept entry still points at.
+- **Resolution strategy is remembered**: Picking a strategy went through the same debounce as typed fields, and the unmount cleanup discarded a pending write. It is now stored immediately. React Hook Form's own blur handler is no longer overwritten.
+- **Wording**: Entries are described as merged into the kept track, not "removed from XML"; files are described as moved to the trash, which is what happens.
+
+## [0.4.0] - 2026-08-21
+
+### 🎉 New Features
+- **History tab**: An audit trail of every library-changing operation, with per-item detail (which entries were merged, which files went to the trash, what failed) and the backup path.
+
+### 🐛 Bug Fixes
+- **Faster tab navigation**: Every tab switch re-ran both cached queries, flashing a skeleton and re-reading the whole duplicate cache even for tabs that never use it.
+
+## [0.3.0] - 2026-08-21
+
+### 🎉 New Features
+- **Cancellable, streaming duplicate scan**: Progress with a track counter, results appearing as they are found, and a cancel that keeps what it found.
+
+## [0.2.3] - 2026-08-21
+
+### 🐛 Bug Fixes
+- **Critical: stopped deleting files that were being kept**: Several rekordbox entries can point at one file. Resolving such a set deleted the losers' paths, which are the kept track's path, destroying the audio the user chose to keep. A path is now only trashed when no remaining track references it.
+- **Files go to the trash**, not straight to permanent deletion.
+
+## [0.2.2] - 2026-08-21
+
+### 🐛 Bug Fixes
+- **Playlists stay complete**: Resolving a duplicate filtered the removed entry out of every playlist, so a playlist holding only that copy silently lost the song. References are now re-pointed at the kept track.
+
+## [0.2.0] - 2026-08-21
+
+### 🎉 New Features
+- **In-app track preview**: Play, pause, seek and volume from any track row, including AIFF (rewrapped to WAV, which Chromium cannot play natively).
+
+### 🐛 Bug Fixes
+- **Relocator handles large libraries**: The search re-scanned the whole tree for every track, so thousands of missing tracks pinned the app until it was killed. The file index is now built once per run.
+
 ## [0.0.5-alpha] - 2025-08-29
 
 ### 🎉 New Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,28 @@ This is an Electron-based desktop application for managing Rekordbox DJ library 
 - `useDuplicates`: Custom hook managing duplicate detection state and operations
 - `useTrackRelocator`: State management for track relocation operations
 - `SettingsPanel`: Configuration UI with Zustand store integration
+- **Rekordbox database import** (`src/main/rekordboxDbLocator.ts`, `rekordboxDbParser.ts`,
+  `rekordboxDbIpc.ts`): reads an encrypted `master.db` into the same `LibraryData` the XML
+  parser produces. Strictly read-only — the file is copied with its `-wal` and the copy is
+  opened `readonly`. Three facts the code depends on, each verified against a real database:
+  the driver defaults to chacha20 so `PRAGMA cipher='sqlcipher'` and `legacy=4` must precede
+  the key; BPM is stored times 100; ordinary cues store `OutMsec = -1`, so only a positive
+  value marks a loop. `master.db` lives in the unversioned `Pioneer/rekordbox` directory on
+  Rekordbox 7. The SQLCipher key is never hardcoded; the user pastes it on the load screen and
+  it persists in the settings store.
+- **Write guard** (`src/main/librarySource.ts`): every write path refuses a `.db` path.
+  Resolve and relocate write XML to `libraryPath`, so a database-backed library would
+  otherwise have been overwritten with XML and destroyed.
+- **Path comparison** (`src/renderer/utils/normalizePath.ts`): macOS stores accents composed
+  or decomposed and treats both as one file, and rekordbox libraries contain both spellings.
+  Any path comparison — duplicate classification and the delete guard — normalises to NFC
+  first, or one file reads as two and the kept track's file can be trashed.
+- **Duplicate kinds** (`src/renderer/utils/classifyDuplicateSet.ts`): distinguishes several
+  entries pointing at one file from genuinely duplicated files, which decides whether
+  resolving can free disk space.
+- **Activity history** (`src/renderer/db/duplicationHistoryDb.ts`): its own Dexie database,
+  separate from the relocation history, recording one entry per library-changing operation
+  with per-item detail. Surfaced by the History tab.
 - `MiniPlayer` / `PlayButton`: In-app track preview (play/pause/seek/volume) via a single
   `<audio>` element + media-chrome transport UI. Audio streams over the custom `media://`
   protocol (`src/main/mediaProtocol.ts`); AIFF is rewrapped to WAV in the renderer

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <img src="assets/icons/256x256.png" alt="Rekordbox Library Fixer" width="128" height="128" style="border-radius: 20px; background-color: white; padding: 10px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);" />
 
 ![Rekordbox Library Fixer](https://img.shields.io/badge/DJ%20Tool-Rekordbox-FF6B35?style=for-the-badge&logo=music&logoColor=white)
-![Version](https://img.shields.io/badge/version-0.4.0-brightgreen?style=for-the-badge)
+![Version](https://img.shields.io/badge/version-0.5.0-brightgreen?style=for-the-badge)
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue?style=for-the-badge)
 ![License](https://img.shields.io/badge/license-Non--Commercial-orange?style=for-the-badge)
 
@@ -51,6 +51,10 @@ I'm aware of commercial tools like Rekordbox Collection Tool (RCT) by MixMasterG
 
 ## What It Does
 
+### Two ways to load your library
+- **XML export** — the classic route: export from Rekordbox, load the file
+- **Rekordbox's own database** — read `master.db` directly, no export needed. Opened strictly read-only from a copy (including its WAL), so Rekordbox can stay open and the database is never written to. It is encrypted, so paste its key once on the load screen. Applying changes still goes through an XML library.
+
 ### Duplicate Detection
 - **Audio fingerprinting**: Finds identical tracks even with different filenames
 - **Metadata matching**: Compares artist, title, BPM, key — configurable
@@ -95,9 +99,11 @@ Quality priority order when lossless preference is enabled:
 - Backup path for each operation, revealable in Finder/Explorer
 
 ### Duplicate files vs duplicate entries
-Two different situations wear the word "duplicate". The app labels each set and lets you filter on it:
-- **Duplicate files** — separate files on disk; resolving can move the extra files to the trash
-- **Same-file entries** — several Rekordbox entries pointing at one file; resolving removes the extra entries and no file is touched
+Two different situations wear the word "duplicate", and the difference decides whether a file leaves your disk. Every set states the real numbers, for example `4 entries · 2 files`, and each entry says what will happen to it:
+- **Extra listing · no file removed** — points at the same file as the entry being kept. Rekordbox simply listed it twice; only the duplicate listing goes.
+- **Own file · trashed if enabled** — a second copy in another folder. The only kind that frees disk space, and only when you tick the trash option.
+
+Resolving **merges** the other entries into the kept one: every playlist that referenced any of them now points at the kept entry, so no playlist loses the song. Files move to the system trash, never straight to deletion, and a file the kept entry still uses is never touched. A filter narrows the list to one kind, and Select All follows it. An in-app help section explains all of this next to the results.
 
 ### Statistics
 - Genre distribution (top 10 with track list on hover)
@@ -350,7 +356,12 @@ Free for personal use. No ads, no subscriptions, no limits.
 
 ## Roadmap
 
-**v0.4.0** *(current)*
+**v0.5.0** *(current)*
+- Read the library straight from Rekordbox's `master.db`, no XML export needed (read-only)
+- Duplicate sets state how many entries and how many real files they involve, with in-app help
+- Never writes over the database, and paths differing only in Unicode form are recognised as one file
+
+**v0.4.0**
 - History tab: an audit trail of everything the app changed, with per-item detail
 - Duplicate files and duplicate Rekordbox entries are told apart and can be cleaned up separately
 - Faster tab navigation, and settings that stay put

--- a/package.json
+++ b/package.json
@@ -201,6 +201,9 @@
           "path": "/Applications"
         }
       ]
-    }
+    },
+    "asarUnpack": [
+      "**/node_modules/better-sqlite3-multiple-ciphers/**"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -107,8 +107,7 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "electron-winstaller",
-      "lzma-native",
-      "better-sqlite3-multiple-ciphers"
+      "lzma-native"
     ]
   },
   "build": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "dependencies": {
     "@radix-ui/react-popover": "^1.1.15",
     "@tanstack/react-router": "^1.170.11",
+    "better-sqlite3-multiple-ciphers": "^13.0.3",
     "crypto-js": "^4.2.0",
     "dexie": "^4.4.3",
     "dexie-react-hooks": "^4.4.0",
@@ -105,7 +106,8 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "electron-winstaller",
-      "lzma-native"
+      "lzma-native",
+      "better-sqlite3-multiple-ciphers"
     ]
   },
   "build": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.170.11
         version: 1.170.11(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      better-sqlite3-multiple-ciphers:
+        specifier: ^13.0.3
+        version: 13.0.3
       crypto-js:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1598,6 +1601,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  better-sqlite3-multiple-ciphers@13.0.3:
+    resolution: {integrity: sha512-UYabM82r1J84TLWc/SszoHs6XopWpl/2HCg3Nui1JUaFXg/VLswzkPowYiRhK/4CftI8dgtikwyZQecMldrGxQ==}
+    engines: {node: '>=22'}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -3027,6 +3034,10 @@ packages:
 
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
+
+  node-addon-api@8.9.2:
+    resolution: {integrity: sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
@@ -5574,6 +5585,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.43: {}
 
+  better-sqlite3-multiple-ciphers@13.0.3:
+    dependencies:
+      node-addon-api: 8.9.2
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -7232,6 +7247,8 @@ snapshots:
 
   node-addon-api@1.7.2:
     optional: true
+
+  node-addon-api@8.9.2: {}
 
   node-api-version@0.2.1:
     dependencies:

--- a/src/main/backupManager.ts
+++ b/src/main/backupManager.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
+import { databaseCandidates, xmlSearchDirs } from './libraryScanner';
 
 export interface BackupEntry {
   path: string;
@@ -84,4 +86,52 @@ export function deleteBackup(backupPath: string): void {
     throw new Error('Refusing to delete a file that is not a backup.');
   }
   fs.rmSync(backupPath, { force: true });
+}
+
+/** The library a backup was taken from: its own name minus the stamp. */
+export function originalPathOfBackup(backupPath: string): string {
+  const dir = path.dirname(backupPath);
+  const name = path.basename(backupPath).replace(BACKUP_SUFFIX, '');
+  return path.join(dir, name);
+}
+
+/**
+ * Every backup on this machine, whatever library it belongs to. Backups are
+ * most wanted exactly when something has gone wrong and no library is loaded,
+ * so finding them must not depend on having one.
+ */
+export function scanAllBackups(
+  home: string = os.homedir(),
+  platform: NodeJS.Platform = process.platform
+): BackupEntry[] {
+  const dirs = new Set<string>(xmlSearchDirs(home));
+  for (const dbPath of databaseCandidates(home, platform)) {
+    dirs.add(path.dirname(dbPath));
+  }
+
+  const backups: BackupEntry[] = [];
+  const seen = new Set<string>();
+  for (const dir of dirs) {
+    let entries: string[];
+    try { entries = fs.readdirSync(dir); } catch { continue; }
+    for (const entry of entries) {
+      if (!BACKUP_SUFFIX.test(entry)) { continue; }
+      const full = path.join(dir, entry);
+      if (seen.has(full)) { continue; }
+      try {
+        const stat = fs.statSync(full);
+        if (!stat.isFile()) { continue; }
+        seen.add(full);
+        const originalPath = originalPathOfBackup(full);
+        backups.push({
+          path: full,
+          originalPath,
+          created: parseBackupTimestamp(entry, stat.mtime),
+          size: stat.size,
+          kind: originalPath.toLowerCase().endsWith('.db') ? 'database' : 'xml',
+        });
+      } catch { /* unreadable, skip */ }
+    }
+  }
+  return backups.sort((a, b) => b.created.getTime() - a.created.getTime());
 }

--- a/src/main/backupManager.ts
+++ b/src/main/backupManager.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface BackupEntry {
+  path: string;
+  /** The library this backup was taken from. */
+  originalPath: string;
+  created: Date;
+  size: number;
+  kind: 'xml' | 'database';
+}
+
+/** Backups are written next to the library as `<library>.backup.<timestamp>`. */
+const BACKUP_SUFFIX = /\.backup\.(.+)$/;
+
+export function isBackupOf(fileName: string, libraryName: string): boolean {
+  return fileName.startsWith(`${libraryName}.backup.`);
+}
+
+/**
+ * Parse the timestamp the app stamps into a backup name. The stamp is an ISO
+ * string with `:` and `.` replaced by `-`, so it has to be turned back before
+ * Date can read it. Falls back to the file's mtime when unparseable.
+ */
+export function parseBackupTimestamp(fileName: string, fallback: Date): Date {
+  const match = fileName.match(BACKUP_SUFFIX);
+  if (!match) { return fallback; }
+  const stamp = match[1];
+  // 2026-08-21T14-05-35-470Z -> 2026-08-21T14:05:35.470Z
+  const iso = stamp.replace(
+    /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
+    '$1T$2:$3:$4.$5Z'
+  );
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? fallback : parsed;
+}
+
+/** Every backup the app has made for this library, newest first. */
+export function listBackups(libraryPath: string): BackupEntry[] {
+  const dir = path.dirname(libraryPath);
+  const libraryName = path.basename(libraryPath);
+  let entries: string[];
+  try { entries = fs.readdirSync(dir); } catch { return []; }
+
+  const backups: BackupEntry[] = [];
+  for (const entry of entries) {
+    if (!isBackupOf(entry, libraryName)) { continue; }
+    const full = path.join(dir, entry);
+    try {
+      const stat = fs.statSync(full);
+      if (!stat.isFile()) { continue; }
+      backups.push({
+        path: full,
+        originalPath: libraryPath,
+        created: parseBackupTimestamp(entry, stat.mtime),
+        size: stat.size,
+        kind: libraryName.toLowerCase().endsWith('.db') ? 'database' : 'xml',
+      });
+    } catch { /* unreadable, skip */ }
+  }
+  return backups.sort((a, b) => b.created.getTime() - a.created.getTime());
+}
+
+/**
+ * Put a backup back in place. The current file is itself backed up first, so
+ * restoring is never the step that loses data — you can always come forward
+ * again.
+ */
+export function restoreBackup(backupPath: string, libraryPath: string): { safetyCopy: string } {
+  if (!fs.existsSync(backupPath)) {
+    throw new Error('That backup no longer exists on disk.');
+  }
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const safetyCopy = `${libraryPath}.backup.${stamp}`;
+  if (fs.existsSync(libraryPath)) {
+    fs.copyFileSync(libraryPath, safetyCopy);
+  }
+  fs.copyFileSync(backupPath, libraryPath);
+  return { safetyCopy };
+}
+
+export function deleteBackup(backupPath: string): void {
+  if (!BACKUP_SUFFIX.test(path.basename(backupPath))) {
+    throw new Error('Refusing to delete a file that is not a backup.');
+  }
+  fs.rmSync(backupPath, { force: true });
+}

--- a/src/main/brokenEntries.ts
+++ b/src/main/brokenEntries.ts
@@ -1,0 +1,69 @@
+import * as fs from 'fs';
+
+export type BrokenReason = 'folder' | 'streaming' | 'truncated' | 'missing' | 'empty';
+
+export interface BrokenEntry {
+  trackId: string;
+  name: string;
+  artist: string;
+  location: string;
+  reason: BrokenReason;
+}
+
+const REASON_TEXT: Record<BrokenReason, string> = {
+  folder: 'Points at a folder, not a file',
+  streaming: 'A streaming track, with no file on disk',
+  truncated: 'The path was cut short and names no file',
+  missing: 'The file is not there any more',
+  empty: 'No location at all',
+};
+
+export function describeReason(reason: BrokenReason): string {
+  return REASON_TEXT[reason];
+}
+
+/**
+ * Why a track's location cannot be a playable file, or null when it looks fine.
+ *
+ * Rekordbox libraries accumulate entries that point at nothing usable: folders
+ * left by bad imports, paths cut off mid-name (often at an "&"), and streaming
+ * tracks whose Location is a made-up file path. They clutter the collection and
+ * confuse duplicate detection, but they are not the same as a track whose file
+ * merely moved — that is what the relocator is for.
+ */
+export function diagnoseLocation(
+  location: string | undefined,
+  exists: (p: string) => boolean = fs.existsSync
+): BrokenReason | null {
+  const path = (location ?? '').trim();
+  if (!path) { return 'empty'; }
+  if (path.endsWith('/') || path.endsWith('\\')) { return 'folder'; }
+  if (/^[a-z]+:[a-z]+:/i.test(path.split('/').pop() ?? '')) { return 'streaming'; }
+  if (!/\.[a-z0-9]{2,5}$/i.test(path)) { return 'truncated'; }
+  if (!exists(path)) { return 'missing'; }
+  return null;
+}
+
+/**
+ * Find entries that can never resolve to a file. Tracks whose file is simply
+ * missing are excluded: those are relocatable, and removing them would throw
+ * away cues and playlist membership the user still wants.
+ */
+export function findBrokenEntries(
+  tracks: Iterable<{ id: string; name?: string; artist?: string; location?: string }>,
+  exists: (p: string) => boolean = fs.existsSync
+): BrokenEntry[] {
+  const broken: BrokenEntry[] = [];
+  for (const track of tracks) {
+    const reason = diagnoseLocation(track.location, exists);
+    if (!reason || reason === 'missing') { continue; }
+    broken.push({
+      trackId: track.id,
+      name: track.name ?? '',
+      artist: track.artist ?? '',
+      location: track.location ?? '',
+      reason,
+    });
+  }
+  return broken;
+}

--- a/src/main/libraryScanner.ts
+++ b/src/main/libraryScanner.ts
@@ -1,0 +1,106 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface FoundLibrary {
+  kind: 'database' | 'xml';
+  path: string;
+  label: string;
+  /** Bytes, for showing which export is the substantial one. */
+  size: number;
+  modified: Date;
+}
+
+/** Where rekordbox keeps its database, newest layout first. */
+export function databaseCandidates(home: string, platform: NodeJS.Platform): string[] {
+  const base = platform === 'win32'
+    ? path.join(home, 'Pioneer')
+    : path.join(home, 'Library', 'Pioneer');
+  return ['rekordbox', 'rekordbox7', 'rekordbox6'].map((d) => path.join(base, d, 'master.db'));
+}
+
+/** Directories people actually save an XML export into. */
+export function xmlSearchDirs(home: string): string[] {
+  return [
+    path.join(home, 'Documents', 'rekordbox'),
+    path.join(home, 'Documents'),
+    path.join(home, 'Desktop'),
+    path.join(home, 'Downloads'),
+    path.join(home, 'Music'),
+    home,
+  ];
+}
+
+/**
+ * A rekordbox export opens with a DJ_PLAYLISTS root element. Checking for it
+ * keeps unrelated XML (project files, tool output) out of the list.
+ */
+export function looksLikeRekordboxXml(filePath: string): boolean {
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const buffer = Buffer.alloc(1024);
+    const read = fs.readSync(fd, buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, read).toString('utf8').includes('DJ_PLAYLISTS');
+  } catch {
+    return false;
+  } finally {
+    if (fd !== null) { try { fs.closeSync(fd); } catch { /* already closed */ } }
+  }
+}
+
+/**
+ * Find libraries this machine already has: rekordbox's own database, and XML
+ * exports lying in the usual places. Only the top level of each directory is
+ * read, so this stays fast on large home folders.
+ */
+export function scanForLibraries(
+  home: string = os.homedir(),
+  platform: NodeJS.Platform = process.platform
+): FoundLibrary[] {
+  const found: FoundLibrary[] = [];
+  const seen = new Set<string>();
+
+  for (const dbPath of databaseCandidates(home, platform)) {
+    try {
+      const stat = fs.statSync(dbPath);
+      if (seen.has(dbPath)) { continue; }
+      seen.add(dbPath);
+      found.push({
+        kind: 'database',
+        path: dbPath,
+        label: `Rekordbox database (${path.basename(path.dirname(dbPath))})`,
+        size: stat.size,
+        modified: stat.mtime,
+      });
+    } catch { /* not installed here */ }
+  }
+
+  for (const dir of xmlSearchDirs(home)) {
+    let entries: string[];
+    try { entries = fs.readdirSync(dir); } catch { continue; }
+    for (const entry of entries) {
+      if (!entry.toLowerCase().endsWith('.xml')) { continue; }
+      const full = path.join(dir, entry);
+      if (seen.has(full)) { continue; }
+      try {
+        const stat = fs.statSync(full);
+        // Rekordbox exports are substantial; skip stray little XML files.
+        if (!stat.isFile() || stat.size < 10_000) { continue; }
+        if (!looksLikeRekordboxXml(full)) { continue; }
+        seen.add(full);
+        found.push({
+          kind: 'xml',
+          path: full,
+          // Two folders can hold an export of the same name; say which.
+          label: `${entry} — ${path.basename(dir)}`,
+          size: stat.size,
+          modified: stat.mtime,
+        });
+      } catch { /* unreadable, skip */ }
+    }
+  }
+
+  // Most recently touched first: that is almost always the one wanted.
+  return found.sort((a, b) => b.modified.getTime() - a.modified.getTime());
+}

--- a/src/main/librarySource.ts
+++ b/src/main/librarySource.ts
@@ -1,0 +1,20 @@
+/**
+ * The app can read a library from an exported XML or straight from
+ * rekordbox's master.db. Writing only ever targets XML: saving XML over
+ * master.db would destroy the database, so any write path must refuse a
+ * database path outright.
+ */
+export function isRekordboxDatabasePath(libraryPath: string): boolean {
+  return /\.db$/i.test((libraryPath ?? '').trim());
+}
+
+export const DATABASE_IS_READ_ONLY =
+  'The rekordbox database is opened read-only. To apply changes, export an XML '
+  + 'from Rekordbox, load that, and save the result back into Rekordbox.';
+
+/** Throws when a write would land on the rekordbox database. */
+export function assertWritableLibraryPath(libraryPath: string): void {
+  if (isRekordboxDatabasePath(libraryPath)) {
+    throw new Error(DATABASE_IS_READ_ONLY);
+  }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8,6 +8,7 @@ import { substitutePlaylistTrackIds } from './playlistSubstitution';
 import { computeDeletablePaths } from './safeDeletePaths';
 import { detectRekordboxDb } from './rekordboxDbLocator';
 import { scanForLibraries } from './libraryScanner';
+import { listBackups, restoreBackup, deleteBackup } from './backupManager';
 import { parseDb } from './rekordboxDbParser';
 import { handleParseRekordboxDb } from './rekordboxDbIpc';
 import { assertWritableLibraryPath } from './librarySource';
@@ -456,6 +457,32 @@ ipcMain.handle('find-duplicates', async (_, options: {
 ipcMain.handle('detect-rekordbox-db', async () => detectRekordboxDb());
 
 ipcMain.handle('scan-for-libraries', async () => scanForLibraries());
+
+ipcMain.handle('list-backups', async (_e, libraryPath: string) => {
+  try {
+    return { success: true, data: listBackups(libraryPath) };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+});
+
+ipcMain.handle('restore-backup', async (_e, args: { backupPath: string; libraryPath: string }) => {
+  try {
+    const { safetyCopy } = restoreBackup(args.backupPath, args.libraryPath);
+    return { success: true, safetyCopy };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+});
+
+ipcMain.handle('delete-backup', async (_e, backupPath: string) => {
+  try {
+    deleteBackup(backupPath);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+});
 
 ipcMain.handle('parse-rekordbox-db', async (_e, args: { dbPath: string; key: string }) =>
   handleParseRekordboxDb(args, parseDb));

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9,6 +9,7 @@ import { computeDeletablePaths } from './safeDeletePaths';
 import { detectRekordboxDb } from './rekordboxDbLocator';
 import { scanForLibraries } from './libraryScanner';
 import { listBackups, restoreBackup, deleteBackup, scanAllBackups } from './backupManager';
+import { findBrokenEntries } from './brokenEntries';
 import { parseDb } from './rekordboxDbParser';
 import { handleParseRekordboxDb } from './rekordboxDbIpc';
 import { assertWritableLibraryPath } from './librarySource';
@@ -457,6 +458,47 @@ ipcMain.handle('find-duplicates', async (_, options: {
 ipcMain.handle('detect-rekordbox-db', async () => detectRekordboxDb());
 
 ipcMain.handle('scan-for-libraries', async () => scanForLibraries());
+
+ipcMain.handle('find-broken-entries', async (_e, tracks: any[]) => {
+  try {
+    return { success: true, data: findBrokenEntries(tracks) };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+});
+
+ipcMain.handle('remove-broken-entries', async (_e, data: { libraryPath: string; trackIds: string[] }) => {
+  try {
+    assertWritableLibraryPath(data.libraryPath);
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const backupPath = `${data.libraryPath}.backup.${stamp}`;
+    require('fs').copyFileSync(data.libraryPath, backupPath);
+
+    const library = await rekordboxParser.parseLibrary(data.libraryPath);
+    const removing = new Set(data.trackIds);
+    let removed = 0;
+    for (const id of removing) {
+      if (library.tracks.delete(id)) { removed++; }
+    }
+
+    // These entries point at nothing, so nothing can inherit their playlist
+    // slots: drop the references rather than re-pointing them.
+    const prune = (playlists: any[]) => {
+      for (const playlist of playlists) {
+        if (playlist.tracks) {
+          playlist.tracks = playlist.tracks.filter((id: string) => !removing.has(id));
+        }
+        if (playlist.children?.length) { prune(playlist.children); }
+      }
+    };
+    prune(library.playlists);
+
+    await rekordboxParser.saveLibrary(library, data.libraryPath);
+    return { success: true, removed, backupPath };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+});
 
 ipcMain.handle('list-backups', async (_e, libraryPath: string) => {
   try {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -621,7 +621,11 @@ ipcMain.handle('resolve-duplicates', async (_, resolution: {
     const remainingLocations = Array.from(library.tracks.values())
       .map((t: any) => t?.location)
       .filter((loc: any): loc is string => typeof loc === 'string' && loc.length > 0);
-    const deletablePaths = computeDeletablePaths(locationsToDelete, remainingLocations);
+    const fsSync = require('fs');
+    const isRegularFile = (p: string) => {
+      try { return fsSync.statSync(p).isFile(); } catch { return false; }
+    };
+    const deletablePaths = computeDeletablePaths(locationsToDelete, remainingLocations, isRegularFile);
     const skippedStillReferenced = locationsToDelete.length - deletablePaths.length;
     if (skippedStillReferenced > 0) {
       safeConsole.log(`🛡️ Skipped ${skippedStillReferenced} path(s) still referenced by kept tracks or duplicated in the delete list`);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7,6 +7,7 @@ import { DuplicateDetector } from './duplicateDetector';
 import { substitutePlaylistTrackIds } from './playlistSubstitution';
 import { computeDeletablePaths } from './safeDeletePaths';
 import { detectRekordboxDb } from './rekordboxDbLocator';
+import { scanForLibraries } from './libraryScanner';
 import { parseDb } from './rekordboxDbParser';
 import { handleParseRekordboxDb } from './rekordboxDbIpc';
 import { assertWritableLibraryPath } from './librarySource';
@@ -453,6 +454,8 @@ ipcMain.handle('find-duplicates', async (_, options: {
 });
 
 ipcMain.handle('detect-rekordbox-db', async () => detectRekordboxDb());
+
+ipcMain.handle('scan-for-libraries', async () => scanForLibraries());
 
 ipcMain.handle('parse-rekordbox-db', async (_e, args: { dbPath: string; key: string }) =>
   handleParseRekordboxDb(args, parseDb));

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8,7 +8,7 @@ import { substitutePlaylistTrackIds } from './playlistSubstitution';
 import { computeDeletablePaths } from './safeDeletePaths';
 import { detectRekordboxDb } from './rekordboxDbLocator';
 import { scanForLibraries } from './libraryScanner';
-import { listBackups, restoreBackup, deleteBackup } from './backupManager';
+import { listBackups, restoreBackup, deleteBackup, scanAllBackups } from './backupManager';
 import { parseDb } from './rekordboxDbParser';
 import { handleParseRekordboxDb } from './rekordboxDbIpc';
 import { assertWritableLibraryPath } from './librarySource';
@@ -460,7 +460,9 @@ ipcMain.handle('scan-for-libraries', async () => scanForLibraries());
 
 ipcMain.handle('list-backups', async (_e, libraryPath: string) => {
   try {
-    return { success: true, data: listBackups(libraryPath) };
+    // Without a loaded library, show every backup on the machine — this page is
+    // most needed exactly when nothing is loaded and something went wrong.
+    return { success: true, data: libraryPath ? listBackups(libraryPath) : scanAllBackups() };
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6,6 +6,9 @@ import { RekordboxParser } from './rekordboxParser';
 import { DuplicateDetector } from './duplicateDetector';
 import { substitutePlaylistTrackIds } from './playlistSubstitution';
 import { computeDeletablePaths } from './safeDeletePaths';
+import { detectRekordboxDb } from './rekordboxDbLocator';
+import { parseDb } from './rekordboxDbParser';
+import { handleParseRekordboxDb } from './rekordboxDbIpc';
 import { Logger } from './logger';
 import { TrackRelocator } from './trackRelocator';
 import { isLossless } from './audioQuality';
@@ -447,6 +450,11 @@ ipcMain.handle('find-duplicates', async (_, options: {
     activeOperations.delete(operationId);
   }
 });
+
+ipcMain.handle('detect-rekordbox-db', async () => detectRekordboxDb());
+
+ipcMain.handle('parse-rekordbox-db', async (_e, args: { dbPath: string; key: string }) =>
+  handleParseRekordboxDb(args, parseDb));
 
 ipcMain.handle('cancel-duplicate-scan', async (_, operationId: string) => {
   const token = activeOperations.get(operationId);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9,6 +9,7 @@ import { computeDeletablePaths } from './safeDeletePaths';
 import { detectRekordboxDb } from './rekordboxDbLocator';
 import { parseDb } from './rekordboxDbParser';
 import { handleParseRekordboxDb } from './rekordboxDbIpc';
+import { assertWritableLibraryPath } from './librarySource';
 import { Logger } from './logger';
 import { TrackRelocator } from './trackRelocator';
 import { isLossless } from './audioQuality';
@@ -477,6 +478,9 @@ ipcMain.handle('resolve-duplicates', async (_, resolution: {
   try {
     // Step 1: Create backup of original XML
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    // Saving writes XML; doing that to master.db would destroy the database.
+    assertWritableLibraryPath(resolution.libraryPath);
+
     const backupPath = `${resolution.libraryPath}.backup.${timestamp}`;
 
     const fs = require('fs');
@@ -638,6 +642,7 @@ ipcMain.handle('save-rekordbox-xml', async (_, data: {
   outputPath: string;
 }) => {
   try {
+    assertWritableLibraryPath(data.outputPath);
     await rekordboxParser.saveLibrary(data.library, data.outputPath);
     logger.logLibrarySaving(data.outputPath, data.library.tracks.size);
     return { success: true };
@@ -716,6 +721,9 @@ ipcMain.handle('auto-relocate-tracks', async (_event, data: {
   activeOperations.set(operationId, cancelToken);
 
   try {
+    // Relocation rewrites the XML; never aim that at master.db.
+    assertWritableLibraryPath(data.libraryPath);
+
     let successCount = 0;
     const results: any[] = [];
     const successfulRelocations: Array<{
@@ -903,7 +911,9 @@ ipcMain.handle('auto-relocate-tracks', async (_event, data: {
         } else {
           // Step 2b: Create backup of original XML
           const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-          const backupPath = `${data.libraryPath}.backup.${timestamp}`;
+          assertWritableLibraryPath(data.libraryPath);
+
+    const backupPath = `${data.libraryPath}.backup.${timestamp}`;
 
           const fs = require('fs');
           fs.copyFileSync(data.libraryPath, backupPath);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -12,6 +12,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('find-duplicates', options),
   detectRekordboxDb: () => ipcRenderer.invoke('detect-rekordbox-db'),
   scanForLibraries: () => ipcRenderer.invoke('scan-for-libraries'),
+  listBackups: (libraryPath: string) => ipcRenderer.invoke('list-backups', libraryPath),
+  restoreBackup: (args: { backupPath: string; libraryPath: string }) =>
+    ipcRenderer.invoke('restore-backup', args),
+  deleteBackup: (backupPath: string) => ipcRenderer.invoke('delete-backup', backupPath),
   parseRekordboxDb: (args: { dbPath: string; key: string }) =>
     ipcRenderer.invoke('parse-rekordbox-db', args),
   cancelDuplicateScan: (operationId: string) =>

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -11,6 +11,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   findDuplicates: (options: any) =>
     ipcRenderer.invoke('find-duplicates', options),
   detectRekordboxDb: () => ipcRenderer.invoke('detect-rekordbox-db'),
+  scanForLibraries: () => ipcRenderer.invoke('scan-for-libraries'),
   parseRekordboxDb: (args: { dbPath: string; key: string }) =>
     ipcRenderer.invoke('parse-rekordbox-db', args),
   cancelDuplicateScan: (operationId: string) =>

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -10,6 +10,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('parse-rekordbox-library', xmlPath),
   findDuplicates: (options: any) =>
     ipcRenderer.invoke('find-duplicates', options),
+  detectRekordboxDb: () => ipcRenderer.invoke('detect-rekordbox-db'),
+  parseRekordboxDb: (args: { dbPath: string; key: string }) =>
+    ipcRenderer.invoke('parse-rekordbox-db', args),
   cancelDuplicateScan: (operationId: string) =>
     ipcRenderer.invoke('cancel-duplicate-scan', operationId),
   onDuplicateScanProgress: (callback: (progress: any) => void) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -12,6 +12,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('find-duplicates', options),
   detectRekordboxDb: () => ipcRenderer.invoke('detect-rekordbox-db'),
   scanForLibraries: () => ipcRenderer.invoke('scan-for-libraries'),
+  findBrokenEntries: (tracks: any[]) => ipcRenderer.invoke('find-broken-entries', tracks),
+  removeBrokenEntries: (data: { libraryPath: string; trackIds: string[] }) =>
+    ipcRenderer.invoke('remove-broken-entries', data),
   listBackups: (libraryPath: string) => ipcRenderer.invoke('list-backups', libraryPath),
   restoreBackup: (args: { backupPath: string; libraryPath: string }) =>
     ipcRenderer.invoke('restore-backup', args),

--- a/src/main/rekordboxDbIpc.ts
+++ b/src/main/rekordboxDbIpc.ts
@@ -1,0 +1,28 @@
+import type { DbLibrary } from './rekordboxDbParser';
+
+/**
+ * Turn a parse attempt into a result the renderer can act on. SQLCipher
+ * reports a wrong key as "file is not a database", which is meaningless to a
+ * DJ, so it is translated here.
+ */
+export async function handleParseRekordboxDb(
+  args: { dbPath: string; key: string },
+  parseDb: (dbPath: string, key: string) => Promise<DbLibrary>
+): Promise<{ success: boolean; data?: DbLibrary; error?: string }> {
+  const key = (args.key ?? '').trim();
+  if (!key) {
+    return { success: false, error: 'No database key — paste your master.db key in Settings.' };
+  }
+  try {
+    return { success: true, data: await parseDb(args.dbPath, key) };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    const wrongKey = /not a database|encrypt|cipher|key/i.test(message);
+    return {
+      success: false,
+      error: wrongKey
+        ? 'Could not decrypt the database — check the key.'
+        : `Could not read the database: ${message}`,
+    };
+  }
+}

--- a/src/main/rekordboxDbLocator.ts
+++ b/src/main/rekordboxDbLocator.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface DbLocation {
+  dbPath: string;
+  /** Which Rekordbox data directory it was found in. */
+  variant: 'rekordbox' | 'rekordbox7' | 'rekordbox6';
+}
+
+/**
+ * Locate Rekordbox's master.db.
+ *
+ * Verified on a real install: Rekordbox 7.2 keeps it in the unversioned
+ * `Pioneer/rekordbox` directory, not `rekordbox7`. Versioned directories are
+ * still checked, because older installs use them.
+ *
+ * `exists` is injected so path resolution can be tested without a filesystem.
+ */
+export function resolveDbPath(
+  home: string,
+  platform: NodeJS.Platform,
+  exists: (p: string) => boolean
+): DbLocation | null {
+  const base = platform === 'win32'
+    ? path.join(home, 'Pioneer')
+    : path.join(home, 'Library', 'Pioneer');
+
+  for (const variant of ['rekordbox', 'rekordbox7', 'rekordbox6'] as const) {
+    const dbPath = path.join(base, variant, 'master.db');
+    if (exists(dbPath)) { return { dbPath, variant }; }
+  }
+  return null;
+}
+
+export function detectRekordboxDb(): {
+  found: boolean;
+  dbPath: string | null;
+  variant: DbLocation['variant'] | null;
+} {
+  const home = process.platform === 'win32' && process.env.APPDATA
+    ? process.env.APPDATA
+    : os.homedir();
+  const location = resolveDbPath(home, process.platform, (p) => fs.existsSync(p));
+  return location
+    ? { found: true, dbPath: location.dbPath, variant: location.variant }
+    : { found: false, dbPath: null, variant: null };
+}

--- a/src/main/rekordboxDbParser.ts
+++ b/src/main/rekordboxDbParser.ts
@@ -1,0 +1,183 @@
+import Database from 'better-sqlite3-multiple-ciphers';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+type Db = InstanceType<typeof Database>;
+
+/**
+ * Read a Rekordbox master.db (SQLCipher) into the same shape the XML parser
+ * produces, so every downstream feature works regardless of where the library
+ * came from.
+ *
+ * Facts verified against a real Rekordbox 7.2 database:
+ * - The driver defaults to chacha20, so `PRAGMA cipher='sqlcipher'` and
+ *   `legacy=4` must be set BEFORE the key or every read fails with
+ *   "file is not a database".
+ * - BPM is stored times 100 (14000 = 140.00).
+ * - A cue is a loop only when OutMsec is positive: ordinary cues store -1,
+ *   not null, so a truthiness check misreads every cue as a loop. Kind
+ *   identifies the hotcue slot (0 = memory cue); it does not mark loops.
+ * - Deleted rows linger with rb_local_deleted = 1 and must be skipped.
+ */
+
+export interface DbTrack {
+  id: string;
+  name: string;
+  artist: string;
+  album?: string;
+  genre?: string;
+  location: string;
+  duration?: number;
+  bitrate?: number;
+  size?: number;
+  bpm?: number;
+  rating?: number;
+  dateAdded?: Date;
+  cues: Array<{ name: string; type: 'CUE'; start: number; hotcue?: number }>;
+  loops: Array<{ name: string; start: number; end: number }>;
+}
+
+export interface DbPlaylist {
+  name: string;
+  tracks: string[];
+  type: 'FOLDER' | 'PLAYLIST';
+  children?: DbPlaylist[];
+}
+
+export interface DbLibrary {
+  libraryPath: string;
+  tracks: Map<string, DbTrack>;
+  playlists: DbPlaylist[];
+}
+
+/** Apply the cipher settings this database needs, in the required order. */
+export function unlockDatabase(db: Db, key: string): void {
+  db.pragma("cipher='sqlcipher'");
+  db.pragma('legacy=4');
+  db.pragma(`key='${key.replace(/'/g, "''")}'`);
+}
+
+/** Ordinary cues store OutMsec = -1; only a positive value marks a loop. */
+const isLoop = (cue: { OutMsec?: number | null }) =>
+  typeof cue.OutMsec === 'number' && cue.OutMsec > 0;
+
+export function mapRowsToLibrary(db: Db, dbPath: string): DbLibrary {
+  const tracks = new Map<string, DbTrack>();
+
+  const contentRows = db.prepare(`
+    SELECT c.ID, c.Title, c.FolderPath, c.Length, c.BitRate, c.FileSize,
+           c.BPM, c.Rating, c.created_at,
+           ar.Name AS ArtistName, al.Name AS AlbumName, g.Name AS GenreName
+    FROM djmdContent c
+    LEFT JOIN djmdArtist ar ON ar.ID = c.ArtistID AND ar.rb_local_deleted = 0
+    LEFT JOIN djmdAlbum  al ON al.ID = c.AlbumID  AND al.rb_local_deleted = 0
+    LEFT JOIN djmdGenre  g  ON g.ID  = c.GenreID  AND g.rb_local_deleted  = 0
+    WHERE c.rb_local_deleted = 0
+  `).all() as any[];
+
+  const cuesByContent = new Map<string, any[]>();
+  for (const row of db.prepare(`
+    SELECT ContentID, Kind, InMsec, OutMsec, Comment
+    FROM djmdCue WHERE rb_local_deleted = 0
+  `).all() as any[]) {
+    const id = String(row.ContentID);
+    if (!cuesByContent.has(id)) { cuesByContent.set(id, []); }
+    cuesByContent.get(id)!.push(row);
+  }
+
+  for (const row of contentRows) {
+    const marks = cuesByContent.get(String(row.ID)) ?? [];
+    tracks.set(String(row.ID), {
+      id: String(row.ID),
+      name: row.Title ?? '',
+      artist: row.ArtistName ?? '',
+      album: row.AlbumName ?? undefined,
+      genre: row.GenreName ?? undefined,
+      location: row.FolderPath ?? '',
+      duration: row.Length ?? undefined,
+      bitrate: row.BitRate ?? undefined,
+      size: row.FileSize ?? undefined,
+      bpm: row.BPM ? row.BPM / 100 : undefined,
+      rating: row.Rating ?? undefined,
+      dateAdded: row.created_at ? new Date(row.created_at) : undefined,
+      cues: marks
+        .filter((m) => !isLoop(m))
+        .map((m) => ({
+          name: m.Comment ?? '',
+          type: 'CUE' as const,
+          start: (m.InMsec ?? 0) / 1000,
+          hotcue: m.Kind > 0 ? m.Kind : undefined,
+        })),
+      loops: marks
+        .filter(isLoop)
+        .map((m) => ({
+          name: m.Comment ?? '',
+          start: (m.InMsec ?? 0) / 1000,
+          end: (m.OutMsec ?? 0) / 1000,
+        })),
+    });
+  }
+
+  return { libraryPath: dbPath, tracks, playlists: buildPlaylists(db) };
+}
+
+function buildPlaylists(db: Db): DbPlaylist[] {
+  const rows = db.prepare(`
+    SELECT ID, Name, ParentID, Attribute
+    FROM djmdPlaylist WHERE rb_local_deleted = 0 ORDER BY Seq
+  `).all() as any[];
+
+  const trackIdsByPlaylist = new Map<string, string[]>();
+  for (const song of db.prepare(`
+    SELECT PlaylistID, ContentID FROM djmdSongPlaylist
+    WHERE rb_local_deleted = 0 ORDER BY TrackNo
+  `).all() as any[]) {
+    const id = String(song.PlaylistID);
+    if (!trackIdsByPlaylist.has(id)) { trackIdsByPlaylist.set(id, []); }
+    trackIdsByPlaylist.get(id)!.push(String(song.ContentID));
+  }
+
+  const nodes = new Map<string, DbPlaylist>();
+  for (const row of rows) {
+    nodes.set(String(row.ID), {
+      name: row.Name ?? '',
+      type: row.Attribute === 1 ? 'FOLDER' : 'PLAYLIST',
+      tracks: trackIdsByPlaylist.get(String(row.ID)) ?? [],
+      children: [],
+    });
+  }
+
+  const roots: DbPlaylist[] = [];
+  for (const row of rows) {
+    const self = nodes.get(String(row.ID))!;
+    const parentId = row.ParentID ? String(row.ParentID) : null;
+    const parent = parentId ? nodes.get(parentId) : undefined;
+    if (parent) { parent.children!.push(self); } else { roots.push(self); }
+  }
+  return roots;
+}
+
+/**
+ * Copy master.db (with its WAL, which holds recent writes) to a temp file and
+ * read that copy read-only, so Rekordbox may stay open and the original is
+ * never touched. The copy is always removed.
+ */
+export async function parseDb(dbPath: string, key: string): Promise<DbLibrary> {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rbdb-'));
+  const copy = path.join(dir, 'master.db');
+  await fs.promises.copyFile(dbPath, copy);
+  for (const suffix of ['-wal', '-shm']) {
+    try { await fs.promises.copyFile(dbPath + suffix, copy + suffix); } catch { /* absent is fine */ }
+  }
+
+  let db: Db | null = null;
+  try {
+    db = new Database(copy, { readonly: true });
+    unlockDatabase(db, key);
+    return mapRowsToLibrary(db, dbPath);
+  } finally {
+    if (db) { db.close(); }
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  }
+}

--- a/src/main/safeDeletePaths.ts
+++ b/src/main/safeDeletePaths.ts
@@ -10,23 +10,28 @@
  * references it. Paths are also de-duplicated so the same file is never
  * unlinked twice (which produced spurious ENOENT failures).
  *
- * Comparison is case-insensitive: macOS and Windows filesystems are typically
- * case-insensitive, so two entries differing only in case are the same file.
+ * Comparison is case-insensitive AND Unicode-normalised: macOS and Windows
+ * filesystems are typically case-insensitive, and macOS stores accents either
+ * composed or decomposed while treating both as one file. Rekordbox libraries
+ * contain both forms for the same track, so comparing raw strings would call
+ * one file two files and delete the copy the kept track still points at.
  */
+const normalize = (p: string) => (p ?? '').normalize('NFC').toLowerCase();
+
 export function computeDeletablePaths(
   candidatePaths: string[],
   remainingLocations: Iterable<string>
 ): string[] {
   const stillReferenced = new Set<string>();
   for (const loc of remainingLocations) {
-    if (loc) { stillReferenced.add(loc.toLowerCase()); }
+    if (loc) { stillReferenced.add(normalize(loc)); }
   }
 
   const seen = new Set<string>();
   const deletable: string[] = [];
   for (const path of candidatePaths) {
     if (!path) { continue; }
-    const key = path.toLowerCase();
+    const key = normalize(path);
     if (stillReferenced.has(key) || seen.has(key)) { continue; }
     seen.add(key);
     deletable.push(path);

--- a/src/main/safeDeletePaths.ts
+++ b/src/main/safeDeletePaths.ts
@@ -20,7 +20,14 @@ const normalize = (p: string) => (p ?? '').normalize('NFC').toLowerCase();
 
 export function computeDeletablePaths(
   candidatePaths: string[],
-  remainingLocations: Iterable<string>
+  remainingLocations: Iterable<string>,
+  /**
+   * Must confirm the path is a regular file. Rekordbox libraries contain
+   * entries whose Location is a FOLDER, a truncated string, or a streaming id
+   * such as `tidal:tracks:123`. Trashing a folder would take an entire album
+   * of music with it, so anything that is not a plain file is refused.
+   */
+  isRegularFile: (p: string) => boolean = () => true
 ): string[] {
   const stillReferenced = new Set<string>();
   for (const loc of remainingLocations) {
@@ -34,6 +41,7 @@ export function computeDeletablePaths(
     const key = normalize(path);
     if (stillReferenced.has(key) || seen.has(key)) { continue; }
     seen.add(key);
+    if (!isRegularFile(path)) { continue; }
     deletable.push(path);
   }
   return deletable;

--- a/src/renderer/AppWithRouter.tsx
+++ b/src/renderer/AppWithRouter.tsx
@@ -13,6 +13,8 @@ interface AppContextType {
   libraryPath: string;
   showNotification: (type: NotificationType, message: string) => void;
   setLibraryData: (data: LibraryData) => void;
+  /** Open a library file by path, e.g. after restoring a backup. */
+  onLoadLibrary?: (path: string) => void;
 }
 
 export const AppContext = createContext<AppContextType | null>(null);
@@ -134,7 +136,8 @@ const AppWithRouter: React.FC = () => {
             libraryData: libraryData as LibraryData,
             libraryPath,
             showNotification,
-            setLibraryData
+            setLibraryData,
+            onLoadLibrary: loadLibrary
           }}>
             {/* No mode="wait": the outgoing page's exit would otherwise have to
                 finish before the new one starts, doubling the perceived delay. */}

--- a/src/renderer/AppWithRouter.tsx
+++ b/src/renderer/AppWithRouter.tsx
@@ -51,6 +51,7 @@ const AppWithRouter: React.FC = () => {
     startupComplete,
     selectLibrary,
     loadLibrary,
+    loadFromDb,
     clearStoredData,
     setLibraryData
   } = useLibrary(showNotification);
@@ -122,7 +123,7 @@ const AppWithRouter: React.FC = () => {
             <p className="text-sm font-te-mono">Parsing library…</p>
           </div>
         ) : !libraryData ? (
-          <EmptyLibraryState onSelectLibrary={selectLibrary} onLoadLibrary={loadLibrary} />
+          <EmptyLibraryState onSelectLibrary={selectLibrary} onLoadLibrary={loadLibrary} onLoadFromDb={loadFromDb} />
         ) : (
           <AppContext.Provider value={{
             libraryData,

--- a/src/renderer/AppWithRouter.tsx
+++ b/src/renderer/AppWithRouter.tsx
@@ -133,6 +133,14 @@ const AppWithRouter: React.FC = () => {
           }}>
             {/* No mode="wait": the outgoing page's exit would otherwise have to
                 finish before the new one starts, doubling the perceived delay. */}
+            {libraryPath.toLowerCase().endsWith('.db') && (
+              <div className="flex-shrink-0 mx-4 mb-2 px-3 py-2 rounded-te border border-te-amber-200 bg-te-amber-100">
+                <p className="text-xs font-te-mono text-te-amber-600 normal-case">
+                  Reading the rekordbox database read-only. Duplicate resolution and
+                  relocation need an XML library to write back to.
+                </p>
+              </div>
+            )}
             <AnimatePresence initial={false}>
               <motion.div
                 key={location.pathname}

--- a/src/renderer/AppWithRouter.tsx
+++ b/src/renderer/AppWithRouter.tsx
@@ -32,6 +32,7 @@ const pathToTab: Record<string, TabType> = {
   '/maintenance': 'maintenance',
   '/statistics': 'statistics',
   '/history': 'history',
+  '/backups': 'backups',
 };
 
 const AppWithRouter: React.FC = () => {

--- a/src/renderer/AppWithRouter.tsx
+++ b/src/renderer/AppWithRouter.tsx
@@ -43,6 +43,10 @@ const AppWithRouter: React.FC = () => {
   // Derive active tab from route
   const activeTab = pathToTab[location.pathname] || 'duplicates';
 
+  // Backups are wanted exactly when something went wrong and nothing is
+  // loaded, so this page must not sit behind the load screen.
+  const worksWithoutLibrary = location.pathname === '/backups';
+
   // Custom hooks
   const { notification, showNotification } = useNotifications();
   const {
@@ -123,11 +127,11 @@ const AppWithRouter: React.FC = () => {
             <div className="w-10 h-10 border-4 border-te-grey-300 border-t-te-orange rounded-full animate-spin" />
             <p className="text-sm font-te-mono">Parsing library…</p>
           </div>
-        ) : !libraryData ? (
+        ) : !libraryData && !worksWithoutLibrary ? (
           <EmptyLibraryState onSelectLibrary={selectLibrary} onLoadLibrary={loadLibrary} onLoadFromDb={loadFromDb} />
         ) : (
           <AppContext.Provider value={{
-            libraryData,
+            libraryData: libraryData as LibraryData,
             libraryPath,
             showNotification,
             setLibraryData

--- a/src/renderer/components/BrokenEntriesPanel.tsx
+++ b/src/renderer/components/BrokenEntriesPanel.tsx
@@ -1,0 +1,165 @@
+import React, { useCallback, useState } from 'react';
+import { AlertTriangle, Search, Trash2 } from 'lucide-react';
+import { useAppContext } from '../AppWithRouter';
+
+interface Broken {
+  trackId: string;
+  name: string;
+  artist: string;
+  location: string;
+  reason: string;
+}
+
+const REASON_LABEL: Record<string, string> = {
+  folder: 'Points at a folder',
+  streaming: 'Streaming track, no file',
+  truncated: 'Path cut short',
+  empty: 'No location',
+};
+
+/**
+ * Entries that can never resolve to a file: folders, streaming tracks and paths
+ * cut off mid-name. They clutter the collection and muddle duplicate detection.
+ * Tracks whose file merely moved are deliberately excluded — those belong to
+ * the relocator, and removing them would throw away cues and playlist slots.
+ */
+export const BrokenEntriesPanel: React.FC = () => {
+  const { libraryData, libraryPath, showNotification, setLibraryData, onLoadLibrary } = useAppContext();
+  const [broken, setBroken] = useState<Broken[] | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+
+  const isDatabase = libraryPath.toLowerCase().endsWith('.db');
+
+  const scan = useCallback(async () => {
+    if (!libraryData) { return; }
+    setBusy(true);
+    try {
+      const tracks = Array.from(libraryData.tracks.values());
+      const result = await window.electronAPI.findBrokenEntries(tracks);
+      if (result.success) {
+        setBroken(result.data ?? []);
+      } else {
+        showNotification('error', result.error || 'Could not check the library');
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [libraryData, showNotification]);
+
+  const remove = useCallback(async () => {
+    if (!broken?.length) { return; }
+    setBusy(true);
+    try {
+      const result = await window.electronAPI.removeBrokenEntries({
+        libraryPath,
+        trackIds: broken.map((b) => b.trackId),
+      });
+      if (result.success) {
+        showNotification(
+          'success',
+          `Removed ${result.removed} broken entr${result.removed === 1 ? 'y' : 'ies'}. A backup was saved first.`
+        );
+        setBroken([]);
+        onLoadLibrary?.(libraryPath);
+      } else {
+        showNotification('error', result.error || 'Could not remove the entries');
+      }
+    } finally {
+      setBusy(false);
+      setConfirming(false);
+    }
+  }, [broken, libraryPath, showNotification, onLoadLibrary]);
+
+  const counts = (broken ?? []).reduce<Record<string, number>>((acc, b) => {
+    acc[b.reason] = (acc[b.reason] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <div className="card p-4">
+      <h3 className="te-title mb-1">Broken entries</h3>
+      <p className="te-label text-xs normal-case mb-3">
+        Tracks whose location can never be a file: folders, streaming tracks, and paths cut
+        short by a bad import. Tracks whose file simply moved are left alone — use the
+        relocator for those.
+      </p>
+
+      {!libraryData ? (
+        <p className="te-label text-xs normal-case">Load a library first.</p>
+      ) : (
+        <>
+          <button onClick={scan} disabled={busy} className="btn-secondary text-xs disabled:opacity-40">
+            <Search size={12} className="inline mr-1.5" />
+            {busy && broken === null ? 'Checking…' : 'Check library'}
+          </button>
+
+          {broken !== null && (
+            broken.length === 0 ? (
+              <p className="te-label text-xs normal-case mt-3">
+                Nothing broken found. Every entry names a real file.
+              </p>
+            ) : (
+              <div className="mt-3">
+                <p className="te-value text-sm mb-1">
+                  {broken.length} broken entr{broken.length === 1 ? 'y' : 'ies'}
+                </p>
+                <p className="te-label text-xs normal-case mb-2">
+                  {Object.entries(counts)
+                    .map(([reason, n]) => `${n} ${(REASON_LABEL[reason] ?? reason).toLowerCase()}`)
+                    .join(' · ')}
+                </p>
+
+                <div className="max-h-52 overflow-y-auto rounded-te border border-te-grey-300 divide-y divide-te-grey-200">
+                  {broken.slice(0, 200).map((entry) => (
+                    <div key={entry.trackId} className="px-2 py-1.5">
+                      <p className="te-value text-xs truncate">
+                        {entry.artist ? `${entry.artist} — ` : ''}{entry.name || '(no title)'}
+                      </p>
+                      <p className="te-path text-[10px] text-te-grey-500 truncate">
+                        {REASON_LABEL[entry.reason] ?? entry.reason}: {entry.location || '(empty)'}
+                      </p>
+                    </div>
+                  ))}
+                  {broken.length > 200 && (
+                    <p className="px-2 py-1.5 te-label text-[10px] normal-case">
+                      …and {broken.length - 200} more. All of them are removed.
+                    </p>
+                  )}
+                </div>
+
+                {isDatabase ? (
+                  <p className="te-label text-xs normal-case mt-3 text-te-amber-600">
+                    <AlertTriangle size={12} className="inline mr-1" />
+                    The rekordbox database is read-only here. Load an XML library to clean it up.
+                  </p>
+                ) : !confirming ? (
+                  <button onClick={() => setConfirming(true)} className="btn-secondary text-xs mt-3">
+                    <Trash2 size={12} className="inline mr-1.5" />
+                    Remove these entries
+                  </button>
+                ) : (
+                  <div className="mt-3">
+                    <p className="text-xs font-te-mono text-te-grey-700 normal-case mb-2">
+                      Removes {broken.length} entries from the library and from any playlist that
+                      lists them. No files are touched — these point at no file. A backup is saved
+                      first, and you can undo this from the Backups tab.
+                    </p>
+                    <div className="flex gap-2">
+                      <button onClick={remove} disabled={busy} className="btn-secondary text-xs">
+                        {busy ? 'Removing…' : `Remove ${broken.length} entries`}
+                      </button>
+                      <button onClick={() => setConfirming(false)} className="btn-ghost text-xs">
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/renderer/components/DuplicateDetector.tsx
+++ b/src/renderer/components/DuplicateDetector.tsx
@@ -17,7 +17,8 @@ import { SettingsPanel } from './SettingsPanel';
 import { countPlaylistMembership } from '../utils/playlistMembership';
 import { pickRecommendedTrack } from '../utils/pickRecommendedTrack';
 import { upsertDuplicateSet } from '../utils/upsertDuplicateSet';
-import { classifyDuplicateSet } from '../utils/classifyDuplicateSet';
+import { normalizePathForCompare } from '../utils/normalizePath';
+import { classifyDuplicateSet, looksLikePlayableFile } from '../utils/classifyDuplicateSet';
 import { duplicationHistoryStorage, type ActivityDetail } from '../db/duplicationHistoryDb';
 
 const DuplicateDetector: React.FC = () => {
@@ -365,11 +366,15 @@ const DuplicateDetector: React.FC = () => {
       // rekordbox entries can point at the same file — that file stays).
       const losingPaths = selectedSets.flatMap((d: any) => {
         const keeper = pickRecommendedTrack(d.tracks, resolutionStrategy, d.pathPreferences);
-        const keeperLocation = (keeper?.location ?? '').toLowerCase();
+        const keeperLocation = normalizePathForCompare(keeper?.location);
         return d.tracks
           .filter((t: any) => t.id !== keeper?.id)
           .map((t: any) => t.location)
-          .filter((loc: string) => loc && loc.toLowerCase() !== keeperLocation);
+          // Only real files can be trashed. Rekordbox also stores folders,
+          // truncated locations and streaming ids; proposing those was alarming
+          // and the backend refuses them anyway.
+          .filter((loc: string) => loc && looksLikePlayableFile(loc)
+            && normalizePathForCompare(loc) !== keeperLocation);
       });
       const uniquePaths = Array.from(new Set(losingPaths));
       if (uniquePaths.length === 0) {
@@ -414,17 +419,43 @@ const DuplicateDetector: React.FC = () => {
           {/* Row 1 — the one thing you came here to do, plus finding your way
               around the result. The search grows; nothing else competes. */}
           <div className="flex items-center gap-3 px-4 pt-4">
-            <PopoverButton
-              onClick={scanForDuplicates}
-              disabled={isScanning}
-              loading={isScanning}
-              icon={Search}
-              title="Scan for Duplicates"
-              description="Analyze your library to find duplicate tracks using advanced algorithms"
-              variant="primary"
-            >
-              {isScanning ? 'Scanning...' : 'Scan for Duplicates'}
-            </PopoverButton>
+            {isScanning ? (
+              /* While scanning, this spot carries the progress and the way out.
+                 It used to live in the empty results area, which disappears as
+                 soon as the first streamed set arrives — taking Cancel with it. */
+              <div className="flex items-center gap-3 flex-1 min-w-0">
+                <button onClick={cancelScan} className="btn-secondary text-xs whitespace-nowrap">
+                  <Trash2 size={13} className="inline mr-1.5" />
+                  Cancel scan
+                </button>
+                <div className="flex-1 min-w-0">
+                  {scanProgress && scanProgress.total > 0 && (
+                    <>
+                      <div className="w-full bg-te-grey-300 rounded-full h-1.5 overflow-hidden">
+                        <div
+                          className="bg-te-orange h-full transition-all duration-200"
+                          style={{ width: `${Math.round((scanProgress.current / scanProgress.total) * 100)}%` }}
+                        />
+                      </div>
+                      <p className="text-[11px] font-te-mono text-te-grey-600 mt-1 truncate normal-case">
+                        {scanProgress.current} / {scanProgress.total} tracks · {scanProgress.setsFound} sets found
+                        {scanProgress.trackName ? ` · ${scanProgress.trackName}` : ''}
+                      </p>
+                    </>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <PopoverButton
+                onClick={scanForDuplicates}
+                icon={Search}
+                title="Scan for Duplicates"
+                description="Analyze your library to find duplicate tracks using advanced algorithms"
+                variant="primary"
+              >
+                Scan for Duplicates
+              </PopoverButton>
+            )}
 
             <input
               type="text"

--- a/src/renderer/components/DuplicateDetector.tsx
+++ b/src/renderer/components/DuplicateDetector.tsx
@@ -12,7 +12,7 @@ import { useDuplicates } from '../hooks';
 import { duplicateStorage } from '../db/duplicatesDb';
 import { useAppContext } from '../AppWithRouter';
 import { VirtualizedDuplicateList } from './VirtualizedDuplicateList';
-import { SettingsSlideout, PopoverButton, PageHeader, DeleteConfirmModal } from './ui';
+import { SettingsSlideout, PopoverButton, PageHeader, DeleteConfirmModal, DuplicateHelp } from './ui';
 import { SettingsPanel } from './SettingsPanel';
 import { countPlaylistMembership } from '../utils/playlistMembership';
 import { pickRecommendedTrack } from '../utils/pickRecommendedTrack';
@@ -524,6 +524,8 @@ const DuplicateDetector: React.FC = () => {
             </div>
           )}
         </div>
+
+        {duplicates.length > 0 && <DuplicateHelp />}
 
         {/* Results List */}
         {duplicates.length > 0 ? (

--- a/src/renderer/components/DuplicateItem.tsx
+++ b/src/renderer/components/DuplicateItem.tsx
@@ -15,11 +15,9 @@ import { useFileOperations } from '../hooks';
 import { ConfidenceBadge, PlayButton } from './ui';
 import { useSettingsStore } from '../stores/settingsStore';
 import { pickRecommendedTrack } from '../utils/pickRecommendedTrack';
-import { classifyDuplicateSet, deletableFileCount } from '../utils/classifyDuplicateSet';
+import { deletableFileCount, distinctFileCount } from '../utils/classifyDuplicateSet';
+import { normalizePathForCompare } from '../utils/normalizePath';
 
-const _ext = (loc: string) => '.' + ((loc || '').split('.').pop()?.toLowerCase() ?? '');
-const isUniversalLossless = (loc: string) => ['.wav', '.aiff', '.aif'].includes(_ext(loc));
-const isFlac = (loc: string) => _ext(loc) === '.flac';
 
 interface DuplicateItemProps {
   duplicate: any;
@@ -62,17 +60,33 @@ const DuplicateItem: React.FC<DuplicateItemProps> = memo(({
 
   // Two very different situations wear the word "duplicate": several rekordbox
   // entries for ONE file (nothing to delete) versus genuinely duplicated files.
-  const kind = useMemo(() => classifyDuplicateSet(duplicate.tracks), [duplicate.tracks]);
   const filesToRemove = useMemo(
     () => deletableFileCount(duplicate.tracks, recommendedTrack?.id),
     [duplicate.tracks, recommendedTrack]
   );
 
+  // Say the actual numbers. "Mixed" left people asking how many files there
+  // really are; "5 entries · 2 files" answers it outright.
+  const fileCount = useMemo(() => distinctFileCount(duplicate.tracks), [duplicate.tracks]);
+  const entryCount = duplicate.tracks.length;
   const kindBadge = {
-    entries: { label: 'Same file · duplicate entries', className: 'bg-te-grey-200 text-te-grey-700 border-te-grey-300' },
-    files: { label: 'Duplicate files', className: 'bg-te-amber-100 text-te-amber-600 border-te-amber-200' },
-    mixed: { label: 'Mixed · some share a file', className: 'bg-te-amber-100 text-te-amber-600 border-te-amber-200' },
-  }[kind];
+    label: `${entryCount} entries · ${fileCount} file${fileCount !== 1 ? 's' : ''}`,
+    className: fileCount > 1
+      ? 'bg-te-amber-100 text-te-amber-600 border-te-amber-200'
+      : 'bg-te-grey-200 text-te-grey-700 border-te-grey-300',
+  };
+
+  /**
+   * An entry that points at the kept file is only an extra listing: merging it
+   * touches no file. One that points elsewhere has a file of its own, which is
+   * what the trash option acts on. Calling both "will be removed" hid that.
+   */
+  const sharesKeptFile = useCallback(
+    (track: any) =>
+      !!recommendedTrack
+      && normalizePathForCompare(track.location) === normalizePathForCompare(recommendedTrack.location),
+    [recommendedTrack]
+  );
 
   const toggleExpanded = useCallback(() => {
     setIsExpanded(prev => !prev);
@@ -125,9 +139,9 @@ const DuplicateItem: React.FC<DuplicateItemProps> = memo(({
               <span className="text-xs text-zinc-400">•</span>
               <span
                 className={`text-[10px] font-te-mono px-1.5 py-0.5 rounded-te border normal-case ${kindBadge.className}`}
-                title={kind === 'entries'
-                  ? 'Every copy points at the same file on disk — resolving removes the extra entries only.'
-                  : `Resolving can move ${filesToRemove} file${filesToRemove !== 1 ? 's' : ''} to the trash.`}
+                title={fileCount === 1
+                  ? 'Every entry points at the same file on disk — resolving removes the extra entries and touches no file.'
+                  : `${entryCount} rekordbox entries pointing at ${fileCount} files on disk. Resolving can move ${filesToRemove} file${filesToRemove !== 1 ? 's' : ''} to the trash.`}
               >
                 {kindBadge.label}
               </span>
@@ -183,9 +197,19 @@ const DuplicateItem: React.FC<DuplicateItemProps> = memo(({
                           <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-te-green-100 text-te-green-600 border border-te-green-200 font-te-mono whitespace-nowrap">
                             <CheckCircle className="w-3 h-3" /> Will be kept
                           </span>
+                        ) : sharesKeptFile(track) ? (
+                          <span
+                            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-te-grey-100 text-te-grey-500 border border-te-grey-200 font-te-mono whitespace-nowrap"
+                            title="This entry points at the same file as the one being kept. Only the extra entry goes; the file stays."
+                          >
+                            Merged · same file
+                          </span>
                         ) : (
-                          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-te-grey-100 text-te-grey-500 border border-te-grey-200 font-te-mono whitespace-nowrap">
-                            Will be removed
+                          <span
+                            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-te-amber-100 text-te-amber-600 border border-te-amber-200 font-te-mono whitespace-nowrap"
+                            title="This entry points at a different file. It is merged into the kept entry, and its file only moves to the trash if you tick the trash option."
+                          >
+                            Merged · separate file
                           </span>
                         )
                       )}

--- a/src/renderer/components/DuplicateItem.tsx
+++ b/src/renderer/components/DuplicateItem.tsx
@@ -200,16 +200,16 @@ const DuplicateItem: React.FC<DuplicateItemProps> = memo(({
                         ) : sharesKeptFile(track) ? (
                           <span
                             className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-te-grey-100 text-te-grey-500 border border-te-grey-200 font-te-mono whitespace-nowrap"
-                            title="This entry points at the same file as the one being kept. Only the extra entry goes; the file stays."
+                            title="Rekordbox lists the kept file twice. Only the extra listing disappears — no file leaves your disk."
                           >
-                            Merged · same file
+                            Extra listing · no file removed
                           </span>
                         ) : (
                           <span
                             className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-te-amber-100 text-te-amber-600 border border-te-amber-200 font-te-mono whitespace-nowrap"
-                            title="This entry points at a different file. It is merged into the kept entry, and its file only moves to the trash if you tick the trash option."
+                            title="A second copy of the song, in another folder. Its listing is merged into the kept one, and this file moves to the trash only if you tick the trash option."
                           >
-                            Merged · separate file
+                            Own file · trashed if enabled
                           </span>
                         )
                       )}

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -55,9 +55,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   resolutionStrategy,
   setResolutionStrategy
 }) => {
-  const rekordboxDbKey = useSettingsStore((state) => state.rekordboxDbKey);
-  const setRekordboxDbKey = useSettingsStore((state) => state.setRekordboxDbKey);
-
   // React Hook Form for local state
   const { register, control, setValue, getValues } = useForm<FormData>({
     defaultValues: {
@@ -254,31 +251,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 </div>
               )}
             </div>
-          </div>
-
-          {/* Rekordbox database key */}
-          <div>
-            <h3 className="font-te-display font-semibold mb-4 text-lg text-te-grey-800 uppercase tracking-te-display">Rekordbox Database</h3>
-            <p className="te-label text-xs normal-case mb-2">
-              Reading rekordbox&apos;s own master.db skips the XML export. The database is
-              opened <strong>read-only</strong>: the app reads a copy and never writes to it,
-              so rekordbox can stay open. Applying changes still goes through an XML export.
-            </p>
-            <p className="te-label text-xs normal-case mb-2">
-              The file is encrypted and the key is not shipped with this app. It is the same
-              for every rekordbox 6/7 install and is documented by the open-source
-              <span className="te-path"> pyrekordbox </span> project (see its
-              &ldquo;Rekordbox 6 database key&rdquo; notes). Paste it once; it stays on this machine.
-            </p>
-            <input
-              type="text"
-              value={rekordboxDbKey}
-              onChange={(e) => setRekordboxDbKey(e.target.value.trim())}
-              placeholder="Paste your master.db key"
-              spellCheck={false}
-              autoComplete="off"
-              className="input w-full te-path text-xs"
-            />
           </div>
 
           {/* Resolution Strategy */}

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -239,9 +239,15 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
           <div>
             <h3 className="font-te-display font-semibold mb-4 text-lg text-te-grey-800 uppercase tracking-te-display">Rekordbox Database</h3>
             <p className="te-label text-xs normal-case mb-2">
-              Reading rekordbox&apos;s own master.db skips the XML export. The file is
-              encrypted, so it needs its key. The app only ever reads a copy of the
-              database, and the key stays on this machine.
+              Reading rekordbox&apos;s own master.db skips the XML export. The database is
+              opened <strong>read-only</strong>: the app reads a copy and never writes to it,
+              so rekordbox can stay open. Applying changes still goes through an XML export.
+            </p>
+            <p className="te-label text-xs normal-case mb-2">
+              The file is encrypted and the key is not shipped with this app. It is the same
+              for every rekordbox 6/7 install and is documented by the open-source
+              <span className="te-path"> pyrekordbox </span> project (see its
+              &ldquo;Rekordbox 6 database key&rdquo; notes). Paste it once; it stays on this machine.
             </p>
             <input
               type="text"

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { FolderOpen, Plus, X, Info } from 'lucide-react';
+import { useSettingsStore } from '../stores/settingsStore';
 import { useForm, useWatch } from 'react-hook-form';
 import type { ScanOptions, ResolutionStrategy } from '../types';
 
@@ -54,6 +55,9 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   resolutionStrategy,
   setResolutionStrategy
 }) => {
+  const rekordboxDbKey = useSettingsStore((state) => state.rekordboxDbKey);
+  const setRekordboxDbKey = useSettingsStore((state) => state.setRekordboxDbKey);
+
   // React Hook Form for local state
   const { register, control, setValue, getValues } = useForm<FormData>({
     defaultValues: {
@@ -229,6 +233,25 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 </div>
               )}
             </div>
+          </div>
+
+          {/* Rekordbox database key */}
+          <div>
+            <h3 className="font-te-display font-semibold mb-4 text-lg text-te-grey-800 uppercase tracking-te-display">Rekordbox Database</h3>
+            <p className="te-label text-xs normal-case mb-2">
+              Reading rekordbox&apos;s own master.db skips the XML export. The file is
+              encrypted, so it needs its key. The app only ever reads a copy of the
+              database, and the key stays on this machine.
+            </p>
+            <input
+              type="text"
+              value={rekordboxDbKey}
+              onChange={(e) => setRekordboxDbKey(e.target.value.trim())}
+              placeholder="Paste your master.db key"
+              spellCheck={false}
+              autoComplete="off"
+              className="input w-full te-path text-xs"
+            />
           </div>
 
           {/* Resolution Strategy */}

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -74,15 +74,20 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
 
   // Debounced sync to Zustand store
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleBlurSyncRef = useRef<(() => void) | null>(null);
 
+  // Typed fields are debounced; the resolution strategy is a single discrete
+  // choice, so it is written immediately. Debouncing it meant a pending write
+  // could still be sitting in the timer when the panel unmounted (the cleanup
+  // clears it), silently discarding the user's pick.
   const syncToStore = useCallback((scanOpts: ScanOptions, resStrategy: ResolutionStrategy) => {
+    setResolutionStrategy(resStrategy);
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
     }
     debounceRef.current = setTimeout(() => {
       setScanOptions(scanOpts);
-      setResolutionStrategy(resStrategy);
-    }, 500); // 500ms debounce
+    }, 500);
   }, [setScanOptions, setResolutionStrategy]);
 
   // Sync changes with debounce.
@@ -172,6 +177,21 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   }, [getValues, setValue]);
 
   // Immediate sync for critical changes (blur handlers)
+  /**
+   * Spreading register() and then declaring onBlur replaces react-hook-form's
+   * own blur handler. Compose the two instead so both run.
+   */
+  const registerWithBlur = useCallback((name: any) => {
+    const field = register(name);
+    return {
+      ...field,
+      onBlur: (event: any) => {
+        field.onBlur(event);
+        handleBlurSyncRef.current?.();
+      },
+    };
+  }, [register]);
+
   const handleBlurSync = useCallback(() => {
     const currentScanOptions = getValues('scanOptions');
     const currentResolutionStrategy = getValues('resolutionStrategy');
@@ -183,6 +203,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     setScanOptions(currentScanOptions);
     setResolutionStrategy(currentResolutionStrategy);
   }, [getValues, setScanOptions, setResolutionStrategy]);
+  handleBlurSyncRef.current = handleBlurSync;
   return (
     <div className="space-y-8 p-6">
           {/* Detection Methods */}
@@ -268,8 +289,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 <input
                   type="radio"
                   value="keep-highest-quality"
-                  {...register('resolutionStrategy')}
-                  onBlur={handleBlurSync}
+                  {...registerWithBlur('resolutionStrategy')}
                   className="mt-1 text-te-orange"
                 />
                 <div className="flex-1">
@@ -279,8 +299,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                     <label className="flex items-center gap-2 mt-2 cursor-pointer">
                       <input
                         type="checkbox"
-                        {...register('scanOptions.preferLossless')}
-                        onBlur={handleBlurSync}
+                        {...registerWithBlur('scanOptions.preferLossless')}
                         className="text-te-orange"
                       />
                       <span className="text-sm text-te-grey-700">Prefer FLAC over lossy formats</span>
@@ -293,8 +312,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 <input
                   type="radio"
                   value="keep-newest"
-                  {...register('resolutionStrategy')}
-                  onBlur={handleBlurSync}
+                  {...registerWithBlur('resolutionStrategy')}
                   className="mt-1 text-te-orange"
                 />
                 <div>
@@ -307,8 +325,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 <input
                   type="radio"
                   value="keep-oldest"
-                  {...register('resolutionStrategy')}
-                  onBlur={handleBlurSync}
+                  {...registerWithBlur('resolutionStrategy')}
                   className="mt-1 text-te-orange"
                 />
                 <div>
@@ -325,8 +342,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 <input
                   type="radio"
                   value="keep-preferred-path"
-                  {...register('resolutionStrategy')}
-                  onBlur={handleBlurSync}
+                  {...registerWithBlur('resolutionStrategy')}
                   className="mt-1 text-te-orange"
                 />
                 <div>
@@ -339,8 +355,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 <input
                   type="radio"
                   value="manual"
-                  {...register('resolutionStrategy')}
-                  onBlur={handleBlurSync}
+                  {...registerWithBlur('resolutionStrategy')}
                   className="mt-1 text-te-orange"
                 />
                 <div>

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
     Wrench,
     Copy,
     History,
+    Archive,
     FolderOpen,
     X,
     HelpCircle
@@ -56,6 +57,13 @@ const navItems = [
         label: 'History',
         icon: History,
         description: 'What the app changed in your library'
+    },
+    {
+        id: 'backups' as TabType,
+        path: '/backups',
+        label: 'Backups',
+        icon: Archive,
+        description: 'Go back to any earlier version of your library'
     }
 ];
 

--- a/src/renderer/components/pages/BackupsPage.tsx
+++ b/src/renderer/components/pages/BackupsPage.tsx
@@ -17,10 +17,11 @@ const formatWhen = (value: string) =>
   });
 
 export const BackupsPage: React.FC = () => {
-  const { libraryPath, showNotification } = useAppContext();
+  const { libraryPath, showNotification, onLoadLibrary } = useAppContext();
   const [backups, setBackups] = useState<Backup[]>([]);
   const [confirming, setConfirming] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [justRestored, setJustRestored] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     // An empty path asks the main process for every backup it can find.
@@ -38,9 +39,12 @@ export const BackupsPage: React.FC = () => {
       if (result.success) {
         showNotification(
           'success',
-          'Library restored. Your previous state was kept as a new backup, so you can go forward again. Reload the library to see it.'
+          'Library restored. Your previous state was kept as a new backup, so you can go forward again.'
         );
         await load();
+        // The restored file is on disk but the app still holds the old one in
+        // memory, so offer to open it rather than leaving the two out of step.
+        setJustRestored(target);
       } else {
         showNotification('error', result.error || 'Could not restore that backup');
       }
@@ -64,6 +68,26 @@ export const BackupsPage: React.FC = () => {
         title="Backups"
         stats={`${backups.length} backup${backups.length !== 1 ? 's' : ''}${libraryPath ? ' of this library' : ' found on this machine'}`}
       />
+
+      {justRestored && (
+        <div className="mx-4 mt-3 rounded-te border border-te-green-200 bg-te-green-100 p-3">
+          <p className="text-xs font-te-mono text-te-green-600 normal-case mb-2">
+            Restored. The app is still showing the library it had open — load the restored
+            version now?
+          </p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => { const p = justRestored; setJustRestored(null); onLoadLibrary?.(p); }}
+              className="btn-secondary text-xs"
+            >
+              Load restored library
+            </button>
+            <button onClick={() => setJustRestored(null)} className="btn-ghost text-xs">
+              Keep what I have open
+            </button>
+          </div>
+        </div>
+      )}
 
       <div className="flex-1 overflow-y-auto p-4">
         {backups.length === 0 ? (

--- a/src/renderer/components/pages/BackupsPage.tsx
+++ b/src/renderer/components/pages/BackupsPage.tsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Archive, RotateCcw, Trash2, FolderOpen, AlertTriangle } from 'lucide-react';
+import { useAppContext } from '../../AppWithRouter';
+import { PageHeader } from '../ui';
+
+interface Backup {
+  path: string;
+  originalPath: string;
+  created: string;
+  size: number;
+  kind: 'xml' | 'database';
+}
+
+const formatWhen = (value: string) =>
+  new Date(value).toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit',
+  });
+
+export const BackupsPage: React.FC = () => {
+  const { libraryPath, showNotification } = useAppContext();
+  const [backups, setBackups] = useState<Backup[]>([]);
+  const [confirming, setConfirming] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!libraryPath) { setBackups([]); return; }
+    const result = await window.electronAPI.listBackups(libraryPath);
+    setBackups(result.success ? (result.data ?? []) : []);
+  }, [libraryPath]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const restore = async (backupPath: string) => {
+    setBusy(true);
+    try {
+      const result = await window.electronAPI.restoreBackup({ backupPath, libraryPath });
+      if (result.success) {
+        showNotification(
+          'success',
+          'Library restored. Your previous state was kept as a new backup, so you can go forward again. Reload the library to see it.'
+        );
+        await load();
+      } else {
+        showNotification('error', result.error || 'Could not restore that backup');
+      }
+    } finally {
+      setBusy(false);
+      setConfirming(null);
+    }
+  };
+
+  const remove = async (backupPath: string) => {
+    const result = await window.electronAPI.deleteBackup(backupPath);
+    if (result.success) { await load(); } else {
+      showNotification('error', result.error || 'Could not delete that backup');
+    }
+  };
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <PageHeader
+        icon={Archive}
+        title="Backups"
+        stats={`${backups.length} backup${backups.length !== 1 ? 's' : ''} of this library`}
+      />
+
+      <div className="flex-1 overflow-y-auto p-4">
+        {!libraryPath ? (
+          <p className="te-label text-center mt-10 normal-case">Load a library to see its backups.</p>
+        ) : backups.length === 0 ? (
+          <div className="text-center mt-10 te-value">
+            <Archive size={44} className="mx-auto mb-3 text-te-grey-400" />
+            <h3 className="te-title mb-2">No backups yet</h3>
+            <p className="te-label normal-case">
+              The app writes one automatically before it changes your library, so the first
+              backup appears the first time you resolve duplicates or apply relocations.
+            </p>
+          </div>
+        ) : (
+          <>
+            <p className="te-label text-xs normal-case mb-3">
+              Taken automatically before each change to{' '}
+              <span className="te-path">{libraryPath}</span>. Restoring keeps your current
+              state as a new backup, so going back is never one-way.
+            </p>
+
+            <div className="space-y-2">
+              {backups.map((backup) => (
+                <div key={backup.path} className="card p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="te-value text-sm">{formatWhen(backup.created)}</p>
+                      <p className="te-label text-xs normal-case">
+                        {(backup.size / 1048576).toFixed(1)} MB · {backup.kind === 'database' ? 'database' : 'XML'}
+                      </p>
+                      <p className="te-path text-[10px] text-te-grey-400 truncate mt-0.5">{backup.path}</p>
+                    </div>
+
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      <button
+                        onClick={() => window.electronAPI.showFileInFolder(backup.path)}
+                        className="btn-ghost text-xs"
+                        title="Reveal in Finder"
+                      >
+                        <FolderOpen size={12} />
+                      </button>
+                      <button
+                        onClick={() => remove(backup.path)}
+                        className="btn-ghost text-xs"
+                        title="Delete this backup"
+                      >
+                        <Trash2 size={12} />
+                      </button>
+                      <button
+                        onClick={() => setConfirming(backup.path)}
+                        disabled={busy}
+                        className="btn-secondary text-xs disabled:opacity-40"
+                      >
+                        <RotateCcw size={12} className="inline mr-1" />
+                        Restore
+                      </button>
+                    </div>
+                  </div>
+
+                  {confirming === backup.path && (
+                    <div className="mt-3 pt-3 border-t border-te-grey-300">
+                      <p className="text-xs font-te-mono text-te-grey-700 normal-case mb-2">
+                        <AlertTriangle size={12} className="inline mr-1 text-te-amber-600" />
+                        This replaces your current library with the version from{' '}
+                        {formatWhen(backup.created)}. Your current state is saved as a new
+                        backup first.
+                      </p>
+                      <div className="flex gap-2">
+                        <button onClick={() => restore(backup.path)} disabled={busy} className="btn-secondary text-xs">
+                          {busy ? 'Restoring…' : 'Restore this version'}
+                        </button>
+                        <button onClick={() => setConfirming(null)} className="btn-ghost text-xs">
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/components/pages/BackupsPage.tsx
+++ b/src/renderer/components/pages/BackupsPage.tsx
@@ -23,8 +23,8 @@ export const BackupsPage: React.FC = () => {
   const [busy, setBusy] = useState(false);
 
   const load = useCallback(async () => {
-    if (!libraryPath) { setBackups([]); return; }
-    const result = await window.electronAPI.listBackups(libraryPath);
+    // An empty path asks the main process for every backup it can find.
+    const result = await window.electronAPI.listBackups(libraryPath || '');
     setBackups(result.success ? (result.data ?? []) : []);
   }, [libraryPath]);
 
@@ -33,7 +33,8 @@ export const BackupsPage: React.FC = () => {
   const restore = async (backupPath: string) => {
     setBusy(true);
     try {
-      const result = await window.electronAPI.restoreBackup({ backupPath, libraryPath });
+      const target = libraryPath || backups.find((b) => b.path === backupPath)?.originalPath || '';
+      const result = await window.electronAPI.restoreBackup({ backupPath, libraryPath: target });
       if (result.success) {
         showNotification(
           'success',
@@ -61,13 +62,11 @@ export const BackupsPage: React.FC = () => {
       <PageHeader
         icon={Archive}
         title="Backups"
-        stats={`${backups.length} backup${backups.length !== 1 ? 's' : ''} of this library`}
+        stats={`${backups.length} backup${backups.length !== 1 ? 's' : ''}${libraryPath ? ' of this library' : ' found on this machine'}`}
       />
 
       <div className="flex-1 overflow-y-auto p-4">
-        {!libraryPath ? (
-          <p className="te-label text-center mt-10 normal-case">Load a library to see its backups.</p>
-        ) : backups.length === 0 ? (
+        {backups.length === 0 ? (
           <div className="text-center mt-10 te-value">
             <Archive size={44} className="mx-auto mb-3 text-te-grey-400" />
             <h3 className="te-title mb-2">No backups yet</h3>
@@ -79,9 +78,10 @@ export const BackupsPage: React.FC = () => {
         ) : (
           <>
             <p className="te-label text-xs normal-case mb-3">
-              Taken automatically before each change to{' '}
-              <span className="te-path">{libraryPath}</span>. Restoring keeps your current
-              state as a new backup, so going back is never one-way.
+              {libraryPath
+                ? <>Taken automatically before each change to <span className="te-path">{libraryPath}</span>.</>
+                : 'Every backup found on this machine. Load its library first if you want to restore one.'}
+              {' '}Restoring keeps your current state as a new backup, so going back is never one-way.
             </p>
 
             <div className="space-y-2">
@@ -92,6 +92,7 @@ export const BackupsPage: React.FC = () => {
                       <p className="te-value text-sm">{formatWhen(backup.created)}</p>
                       <p className="te-label text-xs normal-case">
                         {(backup.size / 1048576).toFixed(1)} MB · {backup.kind === 'database' ? 'database' : 'XML'}
+                        {!libraryPath && <> · of {backup.originalPath.split('/').pop()}</>}
                       </p>
                       <p className="te-path text-[10px] text-te-grey-400 truncate mt-0.5">{backup.path}</p>
                     </div>

--- a/src/renderer/components/pages/MaintenancePage.tsx
+++ b/src/renderer/components/pages/MaintenancePage.tsx
@@ -3,6 +3,7 @@ import { Wrench, FolderOpen, Play, X, CheckCircle, AlertCircle, SkipForward, Inf
 import { PageHeader } from '../ui';
 import { useAppContext } from '../../AppWithRouter';
 import { formatFileSize } from '../../utils';
+import { BrokenEntriesPanel } from '../BrokenEntriesPanel';
 
 // ── Filter & Move types ──────────────────────────────────────────────────────
 type FilterField = 'artist' | 'album' | 'genre' | 'rating' | 'bpm' | 'year' | 'format';
@@ -265,6 +266,11 @@ export const MaintenancePage: React.FC = () => {
   return (
     <div className="p-te-lg h-full overflow-auto">
       <PageHeader title="Maintenance" icon={Wrench} />
+
+      <div className="px-4 pt-4">
+        <BrokenEntriesPanel />
+      </div>
+
 
       {/* Consolidate Library */}
       <div className="bg-white rounded-te shadow-sm p-te-md mt-te-md">

--- a/src/renderer/components/ui/DuplicateHelp.tsx
+++ b/src/renderer/components/ui/DuplicateHelp.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { HelpCircle, ChevronDown, ChevronRight } from 'lucide-react';
+
+/**
+ * Two things wear the word "duplicate" and the difference decides whether a
+ * file leaves the disk. People kept asking, so it is spelled out here rather
+ * than hidden in tooltips.
+ */
+export const DuplicateHelp: React.FC = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="mx-4 mb-3">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1.5 text-xs font-te-mono text-te-grey-600 hover:text-te-orange transition-colors normal-case"
+      >
+        {open ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+        <HelpCircle size={13} />
+        How duplicate resolving works
+      </button>
+
+      {open && (
+        <div className="mt-2 rounded-te border border-te-grey-300 bg-te-grey-100 p-4 space-y-4 text-xs font-te-mono text-te-grey-700 normal-case leading-relaxed">
+          <p>
+            A duplicate set is a group of rekordbox <strong>entries</strong> for the same song.
+            Several entries can point at <strong>one file</strong> on disk, or at genuinely
+            separate copies. The badge on each set says which, for example{' '}
+            <span className="te-value">4 entries · 2 files</span>.
+          </p>
+
+          <div>
+            <p className="te-value mb-1">Resolving a set</p>
+            <p>
+              One entry is kept and the rest are <strong>merged into it</strong>. Every playlist
+              that referenced any of them now points at the kept entry, so no playlist loses the
+              song. Nothing is deleted from your disk unless you tick the trash option.
+            </p>
+          </div>
+
+          <div>
+            <p className="te-value mb-1">What the labels on each entry mean</p>
+            <ul className="space-y-1.5 mt-1">
+              <li>
+                <span className="inline-block px-1.5 py-0.5 rounded bg-te-green-100 text-te-green-600 border border-te-green-200 mr-1.5">Will be kept</span>
+                The entry that survives. Its file always stays.
+              </li>
+              <li>
+                <span className="inline-block px-1.5 py-0.5 rounded bg-te-grey-200 text-te-grey-600 border border-te-grey-300 mr-1.5">Extra listing · no file removed</span>
+                Points at the same file as the kept entry. Rekordbox simply listed it twice;
+                only the duplicate listing goes.
+              </li>
+              <li>
+                <span className="inline-block px-1.5 py-0.5 rounded bg-te-amber-100 text-te-amber-600 border border-te-amber-200 mr-1.5">Own file · trashed if enabled</span>
+                A second copy of the song in another folder. This is the only kind that can free
+                disk space, and only when the trash option is ticked.
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <p className="te-value mb-1">The trash option</p>
+            <p>
+              Files go to the system trash, never straight to deletion, so a mistake is
+              recoverable. A file the kept entry still uses is never touched, even when another
+              entry names the same file differently.
+            </p>
+          </div>
+
+          <div>
+            <p className="te-value mb-1">Filtering</p>
+            <p>
+              The filter above narrows the list to sets with real duplicate files, or to sets
+              that are only duplicate listings. Select All follows the filter, so you can clean
+              up one kind at a time.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/renderer/components/ui/EmptyLibraryState.tsx
+++ b/src/renderer/components/ui/EmptyLibraryState.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import { FolderOpen, FileText } from 'lucide-react';
-import { useSettingsStore } from '../../stores/settingsStore';
+import React, { useEffect, useState } from 'react';
+import { FolderOpen, FileText, Database } from 'lucide-react';
 
 interface EmptyLibraryStateProps {
   onSelectLibrary: () => void;
@@ -11,10 +10,17 @@ interface EmptyLibraryStateProps {
 export const EmptyLibraryState: React.FC<EmptyLibraryStateProps> = ({
   onSelectLibrary,
   onLoadFromDb,
-  onLoadLibrary: _onLoadLibrary
+  onLoadLibrary
 }) => {
-  const dbKey = useSettingsStore((state) => state.rekordboxDbKey);
-  const setRekordboxDbKey = useSettingsStore((state) => state.setRekordboxDbKey);
+  const [found, setFound] = useState<Array<{
+    kind: 'database' | 'xml'; path: string; label: string; size: number; modified: string;
+  }>>([]);
+
+  useEffect(() => {
+    window.electronAPI.scanForLibraries?.()
+      .then((libs) => setFound(libs ?? []))
+      .catch(() => setFound([]));
+  }, []);
 
   return (
     <div className="h-full flex items-center justify-center py-te-xl px-te-lg bg-te-grey-100">
@@ -63,54 +69,42 @@ export const EmptyLibraryState: React.FC<EmptyLibraryStateProps> = ({
           </div>
         </div>
 
-        {/* The database is an alternative to the XML export, so it belongs
-            beside it here, with the key it needs. */}
-        {onLoadFromDb && (
-          <div className="mt-te-lg w-full max-w-md mx-auto">
+        {/* Libraries this machine already has, so the usual case is one click
+            rather than hunting through a file dialog. */}
+        {found.length > 0 && (
+          <div className="mt-te-lg w-full max-w-lg mx-auto">
             <div className="flex items-center gap-3 mb-te-md">
               <div className="flex-1 h-px bg-te-grey-300" />
-              <span className="text-[11px] font-te-mono text-te-grey-400 uppercase tracking-wider">or</span>
+              <span className="text-[11px] font-te-mono text-te-grey-400 uppercase tracking-wider">
+                found on this machine
+              </span>
               <div className="flex-1 h-px bg-te-grey-300" />
             </div>
 
-            <div className="rounded-te border-2 border-te-grey-300 bg-te-grey-100 p-te-md">
-              <h4 className="font-te-display text-sm font-semibold text-te-grey-800 uppercase tracking-te-display mb-1">
-                Read rekordbox&apos;s database
-              </h4>
-              <p className="text-[11px] font-te-mono text-te-grey-500 normal-case leading-relaxed mb-te-sm">
-                Skips the XML export. The database is opened read-only, so rekordbox can stay
-                open. It is encrypted, so paste its key once. Applying changes still needs an
-                XML library.
-              </p>
-
-              <input
-                type="text"
-                value={dbKey}
-                onChange={(e) => setRekordboxDbKey(e.target.value.trim())}
-                placeholder="Paste your master.db key"
-                spellCheck={false}
-                autoComplete="off"
-                className="input w-full te-path text-xs mb-te-sm"
-              />
-
-              <button
-                type="button"
-                onClick={onLoadFromDb}
-                disabled={!dbKey.trim()}
-                className="w-full bg-te-grey-200 hover:bg-te-grey-300 disabled:opacity-40
-                           disabled:hover:bg-te-grey-200 text-te-grey-800 font-te-display text-xs
-                           font-semibold py-te-sm px-te-md rounded-te border-2 border-te-grey-300
-                           transition-all duration-200 uppercase tracking-wider"
-              >
-                Load from database
-              </button>
-
-              {!dbKey.trim() && (
-                <p className="text-[11px] font-te-mono text-te-grey-400 normal-case mt-te-xs">
-                  The key is not shipped with this app. It is the same for every rekordbox 6/7
-                  install and is documented by the open-source pyrekordbox project.
-                </p>
-              )}
+            <div className="space-y-1.5">
+              {found.map((lib) => (
+                <button
+                  key={lib.path}
+                  type="button"
+                  onClick={() => (lib.kind === 'database' ? onLoadFromDb?.() : onLoadLibrary(lib.path))}
+                  title={lib.path}
+                  className="w-full flex items-center gap-3 px-3 py-2 rounded-te border border-te-grey-300
+                             bg-te-grey-100 hover:bg-te-grey-200 hover:border-te-orange
+                             transition-colors text-left group"
+                >
+                  {lib.kind === 'database'
+                    ? <Database className="w-4 h-4 flex-shrink-0 text-te-orange" />
+                    : <FileText className="w-4 h-4 flex-shrink-0 text-te-grey-500" />}
+                  <span className="flex-1 min-w-0">
+                    <span className="block te-path text-xs text-te-grey-800 truncate">{lib.label}</span>
+                    <span className="block text-[10px] font-te-mono text-te-grey-500 normal-case">
+                      {lib.kind === 'database' ? 'rekordbox database · read-only' : 'XML export'}
+                      {' · '}{(lib.size / 1048576).toFixed(1)} MB
+                      {' · '}{new Date(lib.modified).toLocaleDateString()}
+                    </span>
+                  </span>
+                </button>
+              ))}
             </div>
           </div>
         )}

--- a/src/renderer/components/ui/EmptyLibraryState.tsx
+++ b/src/renderer/components/ui/EmptyLibraryState.tsx
@@ -3,11 +3,13 @@ import { FolderOpen, FileText } from 'lucide-react';
 
 interface EmptyLibraryStateProps {
   onSelectLibrary: () => void;
+  onLoadFromDb?: () => void;
   onLoadLibrary: (filePath: string) => void;
 }
 
 export const EmptyLibraryState: React.FC<EmptyLibraryStateProps> = ({
   onSelectLibrary,
+  onLoadFromDb,
   onLoadLibrary: _onLoadLibrary
 }) => {
   return (
@@ -56,6 +58,23 @@ export const EmptyLibraryState: React.FC<EmptyLibraryStateProps> = ({
             </button>
           </div>
         </div>
+
+        {/* Reading rekordbox's own database skips the export step entirely.
+            It is encrypted, so it needs a key the user supplies once. */}
+        {onLoadFromDb && (
+          <div className="mt-te-lg text-center">
+            <button
+              type="button"
+              onClick={onLoadFromDb}
+              className="text-xs font-te-mono text-te-grey-600 hover:text-te-orange underline underline-offset-4 decoration-dotted transition-colors normal-case"
+            >
+              Or read the rekordbox database directly
+            </button>
+            <p className="text-[11px] font-te-mono text-te-grey-400 mt-1 normal-case">
+              No XML export needed. Needs your master.db key, set once in Settings.
+            </p>
+          </div>
+        )}
 
         {/* File Type Info - Minimal TE */}
         <div className="text-center">

--- a/src/renderer/components/ui/EmptyLibraryState.tsx
+++ b/src/renderer/components/ui/EmptyLibraryState.tsx
@@ -102,6 +102,11 @@ export const EmptyLibraryState: React.FC<EmptyLibraryStateProps> = ({
                       {' · '}{(lib.size / 1048576).toFixed(1)} MB
                       {' · '}{new Date(lib.modified).toLocaleDateString()}
                     </span>
+                    {/* The full path: two exports can share a name, and it is
+                        the only way to be sure which file you are opening. */}
+                    <span className="block te-path text-[10px] text-te-grey-400 truncate mt-0.5">
+                      {lib.path}
+                    </span>
                   </span>
                 </button>
               ))}

--- a/src/renderer/components/ui/EmptyLibraryState.tsx
+++ b/src/renderer/components/ui/EmptyLibraryState.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { FolderOpen, FileText, Database } from 'lucide-react';
+import { useSettingsStore } from '../../stores/settingsStore';
 
 interface EmptyLibraryStateProps {
   onSelectLibrary: () => void;
@@ -12,6 +13,9 @@ export const EmptyLibraryState: React.FC<EmptyLibraryStateProps> = ({
   onLoadFromDb,
   onLoadLibrary
 }) => {
+  const dbKey = useSettingsStore((state) => state.rekordboxDbKey);
+  const setRekordboxDbKey = useSettingsStore((state) => state.setRekordboxDbKey);
+  const [askingForKey, setAskingForKey] = useState(false);
   const [found, setFound] = useState<Array<{
     kind: 'database' | 'xml'; path: string; label: string; size: number; modified: string;
   }>>([]);
@@ -86,7 +90,10 @@ export const EmptyLibraryState: React.FC<EmptyLibraryStateProps> = ({
                 <button
                   key={lib.path}
                   type="button"
-                  onClick={() => (lib.kind === 'database' ? onLoadFromDb?.() : onLoadLibrary(lib.path))}
+                  onClick={() => {
+                    if (lib.kind !== 'database') { onLoadLibrary(lib.path); return; }
+                    if (dbKey.trim()) { onLoadFromDb?.(); } else { setAskingForKey(true); }
+                  }}
                   title={lib.path}
                   className="w-full flex items-center gap-3 px-3 py-2 rounded-te border border-te-grey-300
                              bg-te-grey-100 hover:bg-te-grey-200 hover:border-te-orange
@@ -111,6 +118,41 @@ export const EmptyLibraryState: React.FC<EmptyLibraryStateProps> = ({
                 </button>
               ))}
             </div>
+
+            {askingForKey && (
+              <div className="mt-2 rounded-te border border-te-orange bg-te-grey-100 p-3">
+                <p className="text-[11px] font-te-mono text-te-grey-700 normal-case leading-relaxed mb-2">
+                  Rekordbox encrypts its database. Opening it needs the SQLCipher key, which is
+                  the same on every rekordbox 6/7 install and is published by the open-source
+                  <span className="te-value"> pyrekordbox </span> project: see its documentation
+                  under &ldquo;Rekordbox 6 database key&rdquo;. This app does not ship the key.
+                  Paste it once and it stays on this machine.
+                </p>
+                <input
+                  type="text"
+                  value={dbKey}
+                  onChange={(e) => setRekordboxDbKey(e.target.value.trim())}
+                  placeholder="Paste the master.db key (starts with 402fd…)"
+                  spellCheck={false}
+                  autoComplete="off"
+                  autoFocus
+                  className="input w-full te-path text-xs mb-2"
+                />
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onLoadFromDb?.()}
+                    disabled={!dbKey.trim()}
+                    className="btn-secondary text-xs disabled:opacity-40"
+                  >
+                    Open database
+                  </button>
+                  <button type="button" onClick={() => setAskingForKey(false)} className="btn-ghost text-xs">
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         )}
 

--- a/src/renderer/components/ui/EmptyLibraryState.tsx
+++ b/src/renderer/components/ui/EmptyLibraryState.tsx
@@ -71,7 +71,7 @@ export const EmptyLibraryState: React.FC<EmptyLibraryStateProps> = ({
               Or read the rekordbox database directly
             </button>
             <p className="text-[11px] font-te-mono text-te-grey-400 mt-1 normal-case">
-              No XML export needed. Needs your master.db key, set once in Settings.
+              No XML export needed. Read-only, so rekordbox can stay open. Needs your master.db key, set once in Settings.
             </p>
           </div>
         )}

--- a/src/renderer/components/ui/EmptyLibraryState.tsx
+++ b/src/renderer/components/ui/EmptyLibraryState.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FolderOpen, FileText } from 'lucide-react';
+import { useSettingsStore } from '../../stores/settingsStore';
 
 interface EmptyLibraryStateProps {
   onSelectLibrary: () => void;
@@ -12,6 +13,9 @@ export const EmptyLibraryState: React.FC<EmptyLibraryStateProps> = ({
   onLoadFromDb,
   onLoadLibrary: _onLoadLibrary
 }) => {
+  const dbKey = useSettingsStore((state) => state.rekordboxDbKey);
+  const setRekordboxDbKey = useSettingsStore((state) => state.setRekordboxDbKey);
+
   return (
     <div className="h-full flex items-center justify-center py-te-xl px-te-lg bg-te-grey-100">
       <div className="text-center max-w-lg w-full">
@@ -59,20 +63,55 @@ export const EmptyLibraryState: React.FC<EmptyLibraryStateProps> = ({
           </div>
         </div>
 
-        {/* Reading rekordbox's own database skips the export step entirely.
-            It is encrypted, so it needs a key the user supplies once. */}
+        {/* The database is an alternative to the XML export, so it belongs
+            beside it here, with the key it needs. */}
         {onLoadFromDb && (
-          <div className="mt-te-lg text-center">
-            <button
-              type="button"
-              onClick={onLoadFromDb}
-              className="text-xs font-te-mono text-te-grey-600 hover:text-te-orange underline underline-offset-4 decoration-dotted transition-colors normal-case"
-            >
-              Or read the rekordbox database directly
-            </button>
-            <p className="text-[11px] font-te-mono text-te-grey-400 mt-1 normal-case">
-              No XML export needed. Read-only, so rekordbox can stay open. Needs your master.db key, set once in Settings.
-            </p>
+          <div className="mt-te-lg w-full max-w-md mx-auto">
+            <div className="flex items-center gap-3 mb-te-md">
+              <div className="flex-1 h-px bg-te-grey-300" />
+              <span className="text-[11px] font-te-mono text-te-grey-400 uppercase tracking-wider">or</span>
+              <div className="flex-1 h-px bg-te-grey-300" />
+            </div>
+
+            <div className="rounded-te border-2 border-te-grey-300 bg-te-grey-100 p-te-md">
+              <h4 className="font-te-display text-sm font-semibold text-te-grey-800 uppercase tracking-te-display mb-1">
+                Read rekordbox&apos;s database
+              </h4>
+              <p className="text-[11px] font-te-mono text-te-grey-500 normal-case leading-relaxed mb-te-sm">
+                Skips the XML export. The database is opened read-only, so rekordbox can stay
+                open. It is encrypted, so paste its key once. Applying changes still needs an
+                XML library.
+              </p>
+
+              <input
+                type="text"
+                value={dbKey}
+                onChange={(e) => setRekordboxDbKey(e.target.value.trim())}
+                placeholder="Paste your master.db key"
+                spellCheck={false}
+                autoComplete="off"
+                className="input w-full te-path text-xs mb-te-sm"
+              />
+
+              <button
+                type="button"
+                onClick={onLoadFromDb}
+                disabled={!dbKey.trim()}
+                className="w-full bg-te-grey-200 hover:bg-te-grey-300 disabled:opacity-40
+                           disabled:hover:bg-te-grey-200 text-te-grey-800 font-te-display text-xs
+                           font-semibold py-te-sm px-te-md rounded-te border-2 border-te-grey-300
+                           transition-all duration-200 uppercase tracking-wider"
+              >
+                Load from database
+              </button>
+
+              {!dbKey.trim() && (
+                <p className="text-[11px] font-te-mono text-te-grey-400 normal-case mt-te-xs">
+                  The key is not shipped with this app. It is the same for every rekordbox 6/7
+                  install and is documented by the open-source pyrekordbox project.
+                </p>
+              )}
+            </div>
           </div>
         )}
 

--- a/src/renderer/components/ui/index.ts
+++ b/src/renderer/components/ui/index.ts
@@ -19,3 +19,4 @@ export { Skeleton, SkeletonText, SkeletonCard } from './Skeleton';
 export { DeleteConfirmModal } from './DeleteConfirmModal';
 export { MiniPlayer } from './MiniPlayer';
 export { PlayButton } from './PlayButton';
+export { DuplicateHelp } from './DuplicateHelp';

--- a/src/renderer/hooks/useLibrary.ts
+++ b/src/renderer/hooks/useLibrary.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { LibraryData, NotificationType } from '../types';
+import { useSettingsStore } from '../stores/settingsStore';
 
 export const useLibrary = (showNotification: (type: NotificationType, message: string) => void) => {
   const [libraryPath, setLibraryPath] = useState<string>('');
@@ -84,6 +85,41 @@ export const useLibrary = (showNotification: (type: NotificationType, message: s
     }
   }, [libraryPath]);
 
+  /**
+   * Load straight from Rekordbox's own database instead of an exported XML.
+   * Read-only: the app copies master.db and never writes to it.
+   */
+  const loadFromDb = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const detected = await window.electronAPI.detectRekordboxDb();
+      if (!detected.found || !detected.dbPath) {
+        showNotification('error', 'No rekordbox database found on this machine — use XML import instead.');
+        return;
+      }
+
+      const key = useSettingsStore.getState().rekordboxDbKey;
+      if (!key.trim()) {
+        showNotification('error', 'Paste your master.db key in Settings to read the rekordbox database.');
+        return;
+      }
+
+      setLibraryData(null);
+      const result = await window.electronAPI.parseRekordboxDb({ dbPath: detected.dbPath, key });
+      if (result.success && result.data) {
+        setLibraryPath(detected.dbPath);
+        setLibraryData(result.data);
+        showNotification('success', `Loaded ${result.data.tracks.size} tracks from the rekordbox database`);
+      } else {
+        showNotification('error', result.error || 'Could not read the rekordbox database');
+      }
+    } catch {
+      showNotification('error', 'Could not read the rekordbox database');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [showNotification]);
+
   return {
     libraryPath,
     libraryData,
@@ -91,6 +127,7 @@ export const useLibrary = (showNotification: (type: NotificationType, message: s
     startupComplete,
     selectLibrary,
     loadLibrary,
+    loadFromDb,
     clearStoredData,
     setLibraryData,
   };

--- a/src/renderer/hooks/useLibrary.ts
+++ b/src/renderer/hooks/useLibrary.ts
@@ -100,7 +100,7 @@ export const useLibrary = (showNotification: (type: NotificationType, message: s
 
       const key = useSettingsStore.getState().rekordboxDbKey;
       if (!key.trim()) {
-        showNotification('error', 'Paste your master.db key in Settings to read the rekordbox database.');
+        showNotification('error', 'The rekordbox database needs its key — click the database entry on the load screen to paste it.');
         return;
       }
 

--- a/src/renderer/routes.tsx
+++ b/src/renderer/routes.tsx
@@ -6,6 +6,7 @@ import { ImportPage } from './components/pages/ImportPage';
 import { MaintenancePage } from './components/pages/MaintenancePage';
 import { StatisticsPage } from './components/pages/StatisticsPage';
 import { HistoryPage } from './components/pages/HistoryPage';
+import { BackupsPage } from './components/pages/BackupsPage';
 
 // Root route - wraps entire app
 export const rootRoute = createRootRoute({
@@ -49,6 +50,12 @@ export const historyRoute = createRoute({
   component: HistoryPage,
 });
 
+export const backupsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/backups',
+  component: BackupsPage,
+});
+
 // Create the route tree
 const routeTree = rootRoute.addChildren([
   duplicatesRoute,
@@ -57,6 +64,7 @@ const routeTree = rootRoute.addChildren([
   maintenanceRoute,
   statisticsRoute,
   historyRoute,
+  backupsRoute,
 ]);
 
 // Use memory history so file:// protocol in packaged Electron doesn't break routing

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -6,11 +6,14 @@ interface SettingsState {
   // Settings
   scanOptions: ScanOptions;
   resolutionStrategy: ResolutionStrategy;
+  /** SQLCipher key for rekordbox master.db, pasted by the user. */
+  rekordboxDbKey: string;
   relocationOptions: RelocationOptions;
 
   // Actions
   setScanOptions: (options: ScanOptions) => void;
   setResolutionStrategy: (strategy: ResolutionStrategy) => void;
+  setRekordboxDbKey: (key: string) => void;
   updateScanOption: <K extends keyof ScanOptions>(key: K, value: ScanOptions[K]) => void;
   addPathPreference: (path: string) => void;
   removePathPreference: (index: number) => void;
@@ -34,6 +37,7 @@ export const useSettingsStore = create<SettingsState>()(
         preferLossless: false
       },
       resolutionStrategy: 'keep-highest-quality',
+      rekordboxDbKey: '',
       relocationOptions: {
         searchPaths: [],
         searchDepth: 8,
@@ -52,6 +56,8 @@ export const useSettingsStore = create<SettingsState>()(
         console.log('🎯 Zustand: Setting resolution strategy:', strategy);
         set({ resolutionStrategy: strategy });
       },
+
+      setRekordboxDbKey: (key) => set({ rekordboxDbKey: key }),
 
       updateScanOption: (key, value) => {
         console.log(`🔧 Zustand: Updating scan option ${key}:`, value);

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -180,6 +180,8 @@ declare global {
       selectFolder: () => Promise<string | null>;
       parseRekordboxLibrary: (xmlPath: string) => Promise<any>;
       findDuplicates: (options: any) => Promise<any>;
+      detectRekordboxDb: () => Promise<{ found: boolean; dbPath: string | null; variant: string | null }>;
+      parseRekordboxDb: (args: { dbPath: string; key: string }) => Promise<{ success: boolean; data?: any; error?: string }>;
       cancelDuplicateScan: (operationId: string) => Promise<{ success: boolean; error?: string }>;
       onDuplicateScanProgress: (callback: (progress: any) => void) => () => void;
       onDuplicateScanSet: (callback: (payload: any) => void) => () => void;

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -1,6 +1,6 @@
 // Global types and interfaces
 
-export type TabType = 'duplicates' | 'import' | 'relocate' | 'maintenance' | 'statistics' | 'history';
+export type TabType = 'duplicates' | 'import' | 'relocate' | 'maintenance' | 'statistics' | 'history' | 'backups';
 
 export type NotificationType = 'success' | 'error' | 'info';
 
@@ -182,6 +182,9 @@ declare global {
       findDuplicates: (options: any) => Promise<any>;
       detectRekordboxDb: () => Promise<{ found: boolean; dbPath: string | null; variant: string | null }>;
       scanForLibraries: () => Promise<Array<{ kind: 'database' | 'xml'; path: string; label: string; size: number; modified: string }>>;
+      listBackups: (libraryPath: string) => Promise<{ success: boolean; data?: Array<{ path: string; originalPath: string; created: string; size: number; kind: 'xml' | 'database' }>; error?: string }>;
+      restoreBackup: (args: { backupPath: string; libraryPath: string }) => Promise<{ success: boolean; safetyCopy?: string; error?: string }>;
+      deleteBackup: (backupPath: string) => Promise<{ success: boolean; error?: string }>;
       parseRekordboxDb: (args: { dbPath: string; key: string }) => Promise<{ success: boolean; data?: any; error?: string }>;
       cancelDuplicateScan: (operationId: string) => Promise<{ success: boolean; error?: string }>;
       onDuplicateScanProgress: (callback: (progress: any) => void) => () => void;

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -182,6 +182,8 @@ declare global {
       findDuplicates: (options: any) => Promise<any>;
       detectRekordboxDb: () => Promise<{ found: boolean; dbPath: string | null; variant: string | null }>;
       scanForLibraries: () => Promise<Array<{ kind: 'database' | 'xml'; path: string; label: string; size: number; modified: string }>>;
+      findBrokenEntries: (tracks: any[]) => Promise<{ success: boolean; data?: Array<{ trackId: string; name: string; artist: string; location: string; reason: string }>; error?: string }>;
+      removeBrokenEntries: (data: { libraryPath: string; trackIds: string[] }) => Promise<{ success: boolean; removed?: number; backupPath?: string; error?: string }>;
       listBackups: (libraryPath: string) => Promise<{ success: boolean; data?: Array<{ path: string; originalPath: string; created: string; size: number; kind: 'xml' | 'database' }>; error?: string }>;
       restoreBackup: (args: { backupPath: string; libraryPath: string }) => Promise<{ success: boolean; safetyCopy?: string; error?: string }>;
       deleteBackup: (backupPath: string) => Promise<{ success: boolean; error?: string }>;

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -181,6 +181,7 @@ declare global {
       parseRekordboxLibrary: (xmlPath: string) => Promise<any>;
       findDuplicates: (options: any) => Promise<any>;
       detectRekordboxDb: () => Promise<{ found: boolean; dbPath: string | null; variant: string | null }>;
+      scanForLibraries: () => Promise<Array<{ kind: 'database' | 'xml'; path: string; label: string; size: number; modified: string }>>;
       parseRekordboxDb: (args: { dbPath: string; key: string }) => Promise<{ success: boolean; data?: any; error?: string }>;
       cancelDuplicateScan: (operationId: string) => Promise<{ success: boolean; error?: string }>;
       onDuplicateScanProgress: (callback: (progress: any) => void) => () => void;

--- a/src/renderer/utils/classifyDuplicateSet.ts
+++ b/src/renderer/utils/classifyDuplicateSet.ts
@@ -1,5 +1,18 @@
 import { normalizePathForCompare } from './normalizePath';
 
+/**
+ * Rekordbox stores locations that are not files at all: folders (ending in a
+ * separator), truncated strings left over from bad imports, and streaming ids
+ * such as `tidal:tracks:123`. They are not separate copies of anything, so
+ * counting them as files would promise disk space that resolving cannot free.
+ */
+export function looksLikePlayableFile(location: string | undefined): boolean {
+  const path = (location ?? '').trim();
+  if (!path || path.endsWith('/') || path.endsWith('\\')) { return false; }
+  if (/^[a-z]+:[a-z]+:/i.test(path.split('/').pop() ?? '')) { return false; }
+  return /\.[a-z0-9]{2,5}$/i.test(path);
+}
+
 export type DuplicateKind = 'entries' | 'files' | 'mixed';
 
 /**
@@ -17,6 +30,7 @@ export type DuplicateKind = 'entries' | 'files' | 'mixed';
  */
 export function classifyDuplicateSet(tracks: Array<{ location?: string }>): DuplicateKind {
   const paths = tracks
+    .filter((t) => looksLikePlayableFile(t.location))
     .map((t) => normalizePathForCompare(t.location))
     .filter((p) => p.length > 0);
   if (paths.length === 0) { return 'entries'; }
@@ -45,6 +59,9 @@ export function deletableFileCount(
 /** How many distinct files on disk this set actually points at. */
 export function distinctFileCount(tracks: Array<{ location?: string }>): number {
   return new Set(
-    tracks.map((t) => normalizePathForCompare(t.location)).filter((p) => p.length > 0)
+    tracks
+      .filter((t) => looksLikePlayableFile(t.location))
+      .map((t) => normalizePathForCompare(t.location))
+      .filter((p) => p.length > 0)
   ).size;
 }

--- a/src/renderer/utils/classifyDuplicateSet.ts
+++ b/src/renderer/utils/classifyDuplicateSet.ts
@@ -41,3 +41,10 @@ export function deletableFileCount(
   );
   return others.size;
 }
+
+/** How many distinct files on disk this set actually points at. */
+export function distinctFileCount(tracks: Array<{ location?: string }>): number {
+  return new Set(
+    tracks.map((t) => normalizePathForCompare(t.location)).filter((p) => p.length > 0)
+  ).size;
+}

--- a/src/renderer/utils/classifyDuplicateSet.ts
+++ b/src/renderer/utils/classifyDuplicateSet.ts
@@ -1,3 +1,5 @@
+import { normalizePathForCompare } from './normalizePath';
+
 export type DuplicateKind = 'entries' | 'files' | 'mixed';
 
 /**
@@ -10,11 +12,12 @@ export type DuplicateKind = 'entries' | 'files' | 'mixed';
  *                the others can be moved to the trash.
  * - 'mixed'    — some copies share a file, others don't (both of the above).
  *
- * Comparison is case-insensitive: macOS and Windows filesystems are.
+ * Paths are compared normalised: macOS stores accents composed or decomposed
+ * and treats both as one file, so "Bökken" in either form is the same folder.
  */
 export function classifyDuplicateSet(tracks: Array<{ location?: string }>): DuplicateKind {
   const paths = tracks
-    .map((t) => (t.location ?? '').toLowerCase())
+    .map((t) => normalizePathForCompare(t.location))
     .filter((p) => p.length > 0);
   if (paths.length === 0) { return 'entries'; }
 
@@ -29,11 +32,11 @@ export function deletableFileCount(
   tracks: Array<{ id: string; location?: string }>,
   keptTrackId?: string
 ): number {
-  const keptLocation = (tracks.find((t) => t.id === keptTrackId)?.location ?? '').toLowerCase();
+  const keptLocation = normalizePathForCompare(tracks.find((t) => t.id === keptTrackId)?.location);
   const others = new Set(
     tracks
       .filter((t) => t.id !== keptTrackId)
-      .map((t) => (t.location ?? '').toLowerCase())
+      .map((t) => normalizePathForCompare(t.location))
       .filter((p) => p.length > 0 && p !== keptLocation)
   );
   return others.size;

--- a/src/renderer/utils/normalizePath.ts
+++ b/src/renderer/utils/normalizePath.ts
@@ -1,0 +1,13 @@
+/**
+ * Normalise a filesystem path for comparison.
+ *
+ * macOS stores accents either composed (ö = U+00F6) or decomposed
+ * (o + U+0308) and treats both as the same file. Rekordbox libraries contain
+ * both forms for the same track, so a plain string compare reports two
+ * different files where the disk has one. Comparing without this caused a
+ * duplicate set to look like separate files, which would have deleted the
+ * very file the kept track points at.
+ */
+export function normalizePathForCompare(path: string | undefined | null): string {
+  return (path ?? '').normalize('NFC').toLowerCase();
+}

--- a/tests/unit/backup-manager.test.ts
+++ b/tests/unit/backup-manager.test.ts
@@ -8,6 +8,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   isBackupOf, parseBackupTimestamp, listBackups, restoreBackup, deleteBackup,
+  originalPathOfBackup,
 } from '../../src/main/backupManager';
 
 let dir: string;
@@ -96,5 +97,17 @@ describe('deleteBackup', () => {
     const lib = write(LIB, 'current');
     expect(() => deleteBackup(lib)).toThrow(/not a backup/i);
     expect(fs.existsSync(lib)).toBe(true);
+  });
+});
+
+describe('originalPathOfBackup', () => {
+  it('recovers the library a backup came from', () => {
+    expect(originalPathOfBackup('/lib/newlib.xml.backup.2026-08-21T14-05-35-470Z'))
+      .toBe('/lib/newlib.xml');
+  });
+
+  it('works for a database backup', () => {
+    expect(originalPathOfBackup('/p/master.db.backup.2026-08-21T14-05-35-470Z'))
+      .toBe('/p/master.db');
   });
 });

--- a/tests/unit/backup-manager.test.ts
+++ b/tests/unit/backup-manager.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// The global setup stubs fs (existsSync always true, rmSync inert) so the
+// logger stays quiet. These tests are about real files, so use the real module.
+vi.unmock('fs');
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  isBackupOf, parseBackupTimestamp, listBackups, restoreBackup, deleteBackup,
+} from '../../src/main/backupManager';
+
+let dir: string;
+const LIB = 'newlib.xml';
+
+beforeEach(() => {
+  // os.tmpdir(): the repo working tree is write-restricted in some sandboxes,
+  // and these tests genuinely create and delete files.
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bk-'));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+const write = (name: string, body: string) => {
+  fs.writeFileSync(path.join(dir, name), body);
+  return path.join(dir, name);
+};
+
+describe('isBackupOf', () => {
+  it('matches the app\'s backup naming', () => {
+    expect(isBackupOf('newlib.xml.backup.2026-08-21T14-05-35-470Z', LIB)).toBe(true);
+  });
+  it('does not match another library\'s backup', () => {
+    expect(isBackupOf('other.xml.backup.2026-08-21T14-05-35-470Z', LIB)).toBe(false);
+  });
+  it('does not match the library itself', () => {
+    expect(isBackupOf(LIB, LIB)).toBe(false);
+  });
+});
+
+describe('parseBackupTimestamp', () => {
+  it('reads the stamp the app writes', () => {
+    const when = parseBackupTimestamp('newlib.xml.backup.2026-08-21T14-05-35-470Z', new Date(0));
+    expect(when.toISOString()).toBe('2026-08-21T14:05:35.470Z');
+  });
+  it('falls back when the name has no usable stamp', () => {
+    const fallback = new Date('2020-01-01T00:00:00.000Z');
+    expect(parseBackupTimestamp('newlib.xml.backup.garbage', fallback)).toEqual(fallback);
+  });
+});
+
+describe('listBackups', () => {
+  it('lists only this library\'s backups, newest first', () => {
+    const lib = write(LIB, 'current');
+    write(`${LIB}.backup.2026-08-20T10-00-00-000Z`, 'older');
+    write(`${LIB}.backup.2026-08-21T10-00-00-000Z`, 'newer');
+    write('other.xml.backup.2026-08-21T10-00-00-000Z', 'not mine');
+
+    const backups = listBackups(lib);
+    expect(backups).toHaveLength(2);
+    expect(backups[0].path).toContain('2026-08-21');
+    expect(backups[1].path).toContain('2026-08-20');
+  });
+
+  it('returns nothing when the folder has no backups', () => {
+    expect(listBackups(write(LIB, 'current'))).toEqual([]);
+  });
+});
+
+describe('restoreBackup', () => {
+  it('puts the backup back and keeps the current file as a safety copy', () => {
+    const lib = write(LIB, 'current state');
+    const backup = write(`${LIB}.backup.2026-08-20T10-00-00-000Z`, 'old state');
+
+    const { safetyCopy } = restoreBackup(backup, lib);
+
+    expect(fs.readFileSync(lib, 'utf8')).toBe('old state');
+    expect(fs.readFileSync(safetyCopy, 'utf8')).toBe('current state');
+  });
+
+  it('refuses a backup that is gone', () => {
+    const lib = write(LIB, 'current');
+    expect(() => restoreBackup(path.join(dir, 'missing.backup.x'), lib)).toThrow(/no longer exists/i);
+  });
+});
+
+describe('deleteBackup', () => {
+  it('deletes a backup', () => {
+    const backup = write(`${LIB}.backup.2026-08-20T10-00-00-000Z`, 'old');
+    deleteBackup(backup);
+    expect(fs.existsSync(backup)).toBe(false);
+  });
+
+  it('refuses to delete something that is not a backup', () => {
+    const lib = write(LIB, 'current');
+    expect(() => deleteBackup(lib)).toThrow(/not a backup/i);
+    expect(fs.existsSync(lib)).toBe(true);
+  });
+});

--- a/tests/unit/broken-entries.test.ts
+++ b/tests/unit/broken-entries.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { diagnoseLocation, findBrokenEntries, describeReason } from '../../src/main/brokenEntries';
+
+// Every case below was taken from a real rekordbox library.
+const present = () => true;
+const absent = () => false;
+
+describe('diagnoseLocation', () => {
+  it('flags a folder', () => {
+    expect(diagnoseLocation('/Music/Handbraekes/', present)).toBe('folder');
+  });
+
+  it('flags a streaming entry', () => {
+    expect(diagnoseLocation('/app/tidal:tracks:105015500', present)).toBe('streaming');
+  });
+
+  it('flags a path cut short mid-name', () => {
+    expect(diagnoseLocation('/Music/Unknown Album/Pancake - Don&', present)).toBe('truncated');
+  });
+
+  it('flags an empty location', () => {
+    expect(diagnoseLocation('', present)).toBe('empty');
+    expect(diagnoseLocation(undefined, present)).toBe('empty');
+  });
+
+  it('reports a file that is simply gone as missing', () => {
+    expect(diagnoseLocation('/Music/moved.mp3', absent)).toBe('missing');
+  });
+
+  it('passes a normal file', () => {
+    expect(diagnoseLocation('/Music/track.mp3', present)).toBeNull();
+  });
+});
+
+describe('findBrokenEntries', () => {
+  const tracks = [
+    { id: '1', name: 'Fine', artist: 'A', location: '/Music/ok.mp3' },
+    { id: '2', name: 'Folder', artist: 'B', location: '/Music/Handbraekes/' },
+    { id: '3', name: 'Stream', artist: 'C', location: '/app/tidal:tracks:1' },
+    { id: '4', name: 'Cut', artist: 'D', location: '/Music/Remix Medley ' },
+  ];
+
+  it('returns only the entries that can never point at a file', () => {
+    const broken = findBrokenEntries(tracks, present);
+    expect(broken.map((b) => b.trackId)).toEqual(['2', '3', '4']);
+    expect(broken.map((b) => b.reason)).toEqual(['folder', 'streaming', 'truncated']);
+  });
+
+  it('leaves merely missing files alone, because those are relocatable', () => {
+    const broken = findBrokenEntries([{ id: '9', location: '/Music/moved.mp3' }], absent);
+    expect(broken).toEqual([]);
+  });
+
+  it('keeps the track details needed to review before removing', () => {
+    const [first] = findBrokenEntries([tracks[1]], present);
+    expect(first).toMatchObject({ name: 'Folder', artist: 'B', location: '/Music/Handbraekes/' });
+  });
+});
+
+describe('describeReason', () => {
+  it('explains each reason in plain words', () => {
+    expect(describeReason('folder')).toMatch(/folder/i);
+    expect(describeReason('streaming')).toMatch(/streaming/i);
+  });
+});

--- a/tests/unit/classify-duplicate-set.test.ts
+++ b/tests/unit/classify-duplicate-set.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyDuplicateSet, deletableFileCount } from '../../src/renderer/utils/classifyDuplicateSet';
+import { classifyDuplicateSet, deletableFileCount, distinctFileCount } from '../../src/renderer/utils/classifyDuplicateSet';
 
 describe('classifyDuplicateSet', () => {
   it('calls it entries when every copy points at the same file', () => {
@@ -62,5 +62,32 @@ describe('deletableFileCount', () => {
       { id: 'd', location: '/m/dup2.mp3' },
     ];
     expect(deletableFileCount(tracks, 'a')).toBe(2);
+  });
+});
+
+describe('distinctFileCount', () => {
+  it('counts one file when every entry points at it', () => {
+    expect(distinctFileCount([
+      { location: '/m/a.mp3' },
+      { location: '/m/a.mp3' },
+    ])).toBe(1);
+  });
+
+  it('counts the real files behind a mixed set', () => {
+    // The real case: five rekordbox entries, two files on disk.
+    expect(distinctFileCount([
+      { location: '/m/x[www.mp3' },
+      { location: '/m/x[www.MP3Fiber.com].mp3' },
+      { location: '/m/x[www.mp3' },
+      { location: '/m/x[www.MP3Fiber.com].mp3' },
+      { location: '/m/x[www.mp3' },
+    ])).toBe(2);
+  });
+
+  it('folds Unicode variants of one path into a single file', () => {
+    expect(distinctFileCount([
+      { location: '/m/Bökken.mp3' },
+      { location: '/m/Bökken.mp3' },
+    ])).toBe(1);
   });
 });

--- a/tests/unit/classify-duplicate-set.test.ts
+++ b/tests/unit/classify-duplicate-set.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyDuplicateSet, deletableFileCount, distinctFileCount } from '../../src/renderer/utils/classifyDuplicateSet';
+import { classifyDuplicateSet, deletableFileCount, distinctFileCount, looksLikePlayableFile } from '../../src/renderer/utils/classifyDuplicateSet';
 
 describe('classifyDuplicateSet', () => {
   it('calls it entries when every copy points at the same file', () => {
@@ -89,5 +89,40 @@ describe('distinctFileCount', () => {
       { location: '/m/Bökken.mp3' },
       { location: '/m/Bökken.mp3' },
     ])).toBe(1);
+  });
+});
+
+describe('looksLikePlayableFile', () => {
+  it('rejects a folder location, which rekordbox really stores', () => {
+    expect(looksLikePlayableFile('/Music/Handbraekes/')).toBe(false);
+  });
+
+  it('rejects a streaming entry', () => {
+    expect(looksLikePlayableFile('/x/tidal:tracks:105015500')).toBe(false);
+  });
+
+  it('rejects a truncated location with no extension', () => {
+    expect(looksLikePlayableFile('/Music/Unknown Album/Remix Medley ')).toBe(false);
+  });
+
+  it('accepts a normal audio file', () => {
+    expect(looksLikePlayableFile('/Music/track.mp3')).toBe(true);
+  });
+});
+
+describe('counting ignores locations that are not files', () => {
+  it('does not count a folder or a stream as a file', () => {
+    expect(distinctFileCount([
+      { location: '/Music/real.mp3' },
+      { location: '/Music/Handbraekes/' },
+      { location: '/x/tidal:tracks:1' },
+    ])).toBe(1);
+  });
+
+  it('calls a set of unplayable locations entries, not files', () => {
+    expect(classifyDuplicateSet([
+      { location: '/x/tidal:tracks:1' },
+      { location: '/x/tidal:tracks:2' },
+    ])).toBe('entries');
   });
 });

--- a/tests/unit/classify-duplicate-set.test.ts
+++ b/tests/unit/classify-duplicate-set.test.ts
@@ -34,6 +34,15 @@ describe('classifyDuplicateSet', () => {
   it('treats a set without locations as entries', () => {
     expect(classifyDuplicateSet([{}, {}])).toBe('entries');
   });
+
+  it('calls it entries when the paths differ only in Unicode form', () => {
+    // The real case: one rekordbox entry stores "Bökken" composed, the other
+    // decomposed. One folder, one file — nothing to delete.
+    expect(classifyDuplicateSet([
+      { location: '/Music/Bökken/WONTON.mp3' },
+      { location: '/Music/Bökken/WONTON.mp3' },
+    ])).toBe('entries');
+  });
 });
 
 describe('deletableFileCount', () => {

--- a/tests/unit/library-scanner.test.ts
+++ b/tests/unit/library-scanner.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { databaseCandidates, xmlSearchDirs } from '../../src/main/libraryScanner';
+
+describe('databaseCandidates', () => {
+  it('looks in the unversioned directory first, as rekordbox 7 uses it', () => {
+    const paths = databaseCandidates('/Users/dj', 'darwin');
+    expect(paths[0]).toBe('/Users/dj/Library/Pioneer/rekordbox/master.db');
+    expect(paths).toHaveLength(3);
+  });
+
+  it('uses the Pioneer directory under APPDATA on Windows', () => {
+    const paths = databaseCandidates('C:\\Users\\dj\\AppData\\Roaming', 'win32');
+    expect(paths[0].replace(/\\/g, '/')).toContain('Pioneer/rekordbox/master.db');
+  });
+});
+
+describe('xmlSearchDirs', () => {
+  it('includes the places people actually export to', () => {
+    const dirs = xmlSearchDirs('/Users/dj');
+    expect(dirs).toContain('/Users/dj/Documents/rekordbox');
+    expect(dirs).toContain('/Users/dj/Desktop');
+    expect(dirs).toContain('/Users/dj/Downloads');
+  });
+
+  it('checks the rekordbox folder before the wider Documents folder', () => {
+    const dirs = xmlSearchDirs('/Users/dj');
+    expect(dirs.indexOf('/Users/dj/Documents/rekordbox')).toBeLessThan(dirs.indexOf('/Users/dj/Documents'));
+  });
+});

--- a/tests/unit/library-source.test.ts
+++ b/tests/unit/library-source.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isRekordboxDatabasePath,
+  assertWritableLibraryPath,
+  DATABASE_IS_READ_ONLY,
+} from '../../src/main/librarySource';
+
+describe('isRekordboxDatabasePath', () => {
+  it('recognises master.db', () => {
+    expect(isRekordboxDatabasePath('/Users/dj/Library/Pioneer/rekordbox/master.db')).toBe(true);
+  });
+
+  it('recognises it regardless of case', () => {
+    expect(isRekordboxDatabasePath('/x/MASTER.DB')).toBe(true);
+  });
+
+  it('does not flag an XML library', () => {
+    expect(isRekordboxDatabasePath('/Users/dj/Documents/rekordbox/newlib.xml')).toBe(false);
+  });
+
+  it('does not flag an empty path', () => {
+    expect(isRekordboxDatabasePath('')).toBe(false);
+  });
+});
+
+describe('assertWritableLibraryPath', () => {
+  it('refuses to write over the rekordbox database', () => {
+    expect(() => assertWritableLibraryPath('/x/master.db')).toThrow(DATABASE_IS_READ_ONLY);
+  });
+
+  it('allows an XML path through', () => {
+    expect(() => assertWritableLibraryPath('/x/lib.xml')).not.toThrow();
+  });
+});

--- a/tests/unit/normalize-path.test.ts
+++ b/tests/unit/normalize-path.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { normalizePathForCompare } from '../../src/renderer/utils/normalizePath';
+
+// Same name, different Unicode forms — exactly what a real library contains.
+const COMPOSED = '/Music/Bökken/WONTON.mp3';        // ö as one code point
+const DECOMPOSED = '/Music/Bökken/WONTON.mp3';     // o + combining diaeresis
+
+describe('normalizePathForCompare', () => {
+  it('makes composed and decomposed accents compare equal', () => {
+    expect(COMPOSED).not.toBe(DECOMPOSED);
+    expect(normalizePathForCompare(COMPOSED)).toBe(normalizePathForCompare(DECOMPOSED));
+  });
+
+  it('ignores case, as macOS and Windows filesystems do', () => {
+    expect(normalizePathForCompare('/Music/Song.MP3')).toBe(normalizePathForCompare('/music/song.mp3'));
+  });
+
+  it('still tells genuinely different paths apart', () => {
+    expect(normalizePathForCompare('/Music/a.mp3')).not.toBe(normalizePathForCompare('/Music/b.mp3'));
+  });
+
+  it('handles missing values', () => {
+    expect(normalizePathForCompare(undefined)).toBe('');
+    expect(normalizePathForCompare(null)).toBe('');
+  });
+});

--- a/tests/unit/rekordbox-db-ipc.test.ts
+++ b/tests/unit/rekordbox-db-ipc.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleParseRekordboxDb } from '../../src/main/rekordboxDbIpc';
+
+const library = { libraryPath: '/db', tracks: new Map(), playlists: [] } as any;
+
+describe('handleParseRekordboxDb', () => {
+  it('returns the parsed library on success', async () => {
+    const parseDb = vi.fn().mockResolvedValue(library);
+    const result = await handleParseRekordboxDb({ dbPath: '/db', key: 'abc' }, parseDb);
+    expect(result).toEqual({ success: true, data: library });
+    expect(parseDb).toHaveBeenCalledWith('/db', 'abc');
+  });
+
+  it('refuses an empty key without touching the database', async () => {
+    const parseDb = vi.fn();
+    const result = await handleParseRekordboxDb({ dbPath: '/db', key: '   ' }, parseDb);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/key/i);
+    expect(parseDb).not.toHaveBeenCalled();
+  });
+
+  it('trims a pasted key', async () => {
+    const parseDb = vi.fn().mockResolvedValue(library);
+    await handleParseRekordboxDb({ dbPath: '/db', key: '  abc\n' }, parseDb);
+    expect(parseDb).toHaveBeenCalledWith('/db', 'abc');
+  });
+
+  it('explains a wrong key instead of repeating SQLCipher wording', async () => {
+    const parseDb = vi.fn().mockRejectedValue(new Error('file is not a database'));
+    const result = await handleParseRekordboxDb({ dbPath: '/db', key: 'wrong' }, parseDb);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/check the key/i);
+    expect(result.error).not.toMatch(/not a database/i);
+  });
+
+  it('passes through an unrelated failure', async () => {
+    const parseDb = vi.fn().mockRejectedValue(new Error('EACCES: permission denied'));
+    const result = await handleParseRekordboxDb({ dbPath: '/db', key: 'abc' }, parseDb);
+    expect(result.error).toMatch(/EACCES/);
+  });
+});

--- a/tests/unit/rekordbox-db-locator.test.ts
+++ b/tests/unit/rekordbox-db-locator.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDbPath } from '../../src/main/rekordboxDbLocator';
+
+const HOME = '/Users/dj';
+
+describe('resolveDbPath', () => {
+  it('finds the unversioned rekordbox directory used by Rekordbox 7', () => {
+    const exists = (p: string) => p === '/Users/dj/Library/Pioneer/rekordbox/master.db';
+    expect(resolveDbPath(HOME, 'darwin', exists)).toEqual({
+      dbPath: '/Users/dj/Library/Pioneer/rekordbox/master.db',
+      variant: 'rekordbox',
+    });
+  });
+
+  it('falls back to a versioned directory when the unversioned one is absent', () => {
+    const exists = (p: string) => p.includes('rekordbox6');
+    expect(resolveDbPath(HOME, 'darwin', exists)).toEqual({
+      dbPath: '/Users/dj/Library/Pioneer/rekordbox6/master.db',
+      variant: 'rekordbox6',
+    });
+  });
+
+  it('prefers the unversioned directory when several exist', () => {
+    const exists = () => true;
+    expect(resolveDbPath(HOME, 'darwin', exists)?.variant).toBe('rekordbox');
+  });
+
+  it('resolves under APPDATA on Windows', () => {
+    const appData = 'C:\\Users\\dj\\AppData\\Roaming';
+    const exists = (p: string) => p.includes('rekordbox') && p.endsWith('master.db');
+    const result = resolveDbPath(appData, 'win32', exists);
+    expect(result?.dbPath.replace(/\\/g, '/')).toContain('Pioneer/rekordbox/master.db');
+  });
+
+  it('returns null when no database exists', () => {
+    expect(resolveDbPath(HOME, 'darwin', () => false)).toBeNull();
+  });
+});

--- a/tests/unit/rekordbox-db-parser.test.ts
+++ b/tests/unit/rekordbox-db-parser.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3-multiple-ciphers';
+import * as fs from 'fs';
+import * as path from 'path';
+import { mapRowsToLibrary } from '../../src/main/rekordboxDbParser';
+
+let file: string;
+let db: InstanceType<typeof Database>;
+
+beforeEach(() => {
+  file = path.join(process.cwd(), `.dbtest-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+  db = new Database(file);
+  db.exec(`
+    CREATE TABLE djmdArtist (ID TEXT PRIMARY KEY, Name TEXT, rb_local_deleted INTEGER DEFAULT 0);
+    CREATE TABLE djmdAlbum  (ID TEXT PRIMARY KEY, Name TEXT, rb_local_deleted INTEGER DEFAULT 0);
+    CREATE TABLE djmdGenre  (ID TEXT PRIMARY KEY, Name TEXT, rb_local_deleted INTEGER DEFAULT 0);
+    CREATE TABLE djmdContent (
+      ID TEXT PRIMARY KEY, Title TEXT, ArtistID TEXT, AlbumID TEXT, GenreID TEXT,
+      FolderPath TEXT, Length INTEGER, BitRate INTEGER, FileSize INTEGER,
+      BPM INTEGER, Rating INTEGER, created_at TEXT, rb_local_deleted INTEGER DEFAULT 0);
+    CREATE TABLE djmdCue (
+      ID TEXT PRIMARY KEY, ContentID TEXT, Kind INTEGER, InMsec INTEGER,
+      OutMsec INTEGER, Comment TEXT, rb_local_deleted INTEGER DEFAULT 0);
+    CREATE TABLE djmdPlaylist (
+      ID TEXT PRIMARY KEY, Name TEXT, ParentID TEXT, Attribute INTEGER,
+      Seq INTEGER, rb_local_deleted INTEGER DEFAULT 0);
+    CREATE TABLE djmdSongPlaylist (
+      ID TEXT PRIMARY KEY, PlaylistID TEXT, ContentID TEXT, TrackNo INTEGER,
+      rb_local_deleted INTEGER DEFAULT 0);
+  `);
+  db.exec(`
+    INSERT INTO djmdArtist VALUES ('a1','Roméo Elvis',0);
+    INSERT INTO djmdAlbum  VALUES ('al1','Morale',0);
+    INSERT INTO djmdGenre  VALUES ('g1','Hip Hop',0);
+    INSERT INTO djmdContent VALUES
+      ('t1','Bruxelles arrive','a1','al1','g1','/Music/bx.mp3',217,320,8000000,14000,4,'2020-10-03 12:14:15.969 +00:00',0);
+    INSERT INTO djmdContent VALUES
+      ('t2','Deleted','a1','al1','g1','/Music/gone.mp3',100,128,1000,8750,0,'2021-01-01 00:00:00 +00:00',1);
+    INSERT INTO djmdCue VALUES ('c1','t1',0,15000,-1,'Intro',0);
+    INSERT INTO djmdCue VALUES ('c2','t1',3,30000,45000,'Loop A',0);
+    INSERT INTO djmdCue VALUES ('c3','t1',2,60000,-1,'Hot B',0);
+    INSERT INTO djmdPlaylist VALUES ('p0','Crates',NULL,1,0,0);
+    INSERT INTO djmdPlaylist VALUES ('p1','Gig',  'p0',0,1,0);
+    INSERT INTO djmdSongPlaylist VALUES ('sp1','p1','t1',1,0);
+  `);
+  db.close();
+  db = new Database(file, { readonly: true });
+});
+
+afterEach(() => {
+  db.close();
+  fs.rmSync(file, { force: true });
+});
+
+describe('mapRowsToLibrary', () => {
+  it('maps a track with its joined artist, album and genre', () => {
+    const t = mapRowsToLibrary(db, file).tracks.get('t1')!;
+    expect(t.name).toBe('Bruxelles arrive');
+    expect(t.artist).toBe('Roméo Elvis');
+    expect(t.album).toBe('Morale');
+    expect(t.genre).toBe('Hip Hop');
+    expect(t.location).toBe('/Music/bx.mp3');
+    expect(t.duration).toBe(217);
+    expect(t.bitrate).toBe(320);
+    expect(t.size).toBe(8000000);
+    expect(t.rating).toBe(4);
+  });
+
+  it('scales BPM down by 100, as rekordbox stores it', () => {
+    expect(mapRowsToLibrary(db, file).tracks.get('t1')!.bpm).toBe(140);
+  });
+
+  it('skips rows marked rb_local_deleted', () => {
+    const lib = mapRowsToLibrary(db, file);
+    expect(lib.tracks.has('t2')).toBe(false);
+    expect(lib.tracks.size).toBe(1);
+  });
+
+  it('treats only a positive OutMsec as a loop (ordinary cues store -1)', () => {
+    const t = mapRowsToLibrary(db, file).tracks.get('t1')!;
+    expect(t.loops).toHaveLength(1);
+    expect(t.loops[0]).toMatchObject({ start: 30, end: 45, name: 'Loop A' });
+    expect(t.cues).toHaveLength(2);
+    expect(t.cues.map((c) => c.start).sort()).toEqual([15, 60]);
+  });
+
+  it('records the hotcue slot from Kind, leaving memory cues (Kind 0) without one', () => {
+    const t = mapRowsToLibrary(db, file).tracks.get('t1')!;
+    expect(t.cues.find((c) => c.start === 15)!.hotcue).toBeUndefined();
+    expect(t.cues.find((c) => c.start === 60)!.hotcue).toBe(2);
+  });
+
+  it('parses created_at into a date', () => {
+    const t = mapRowsToLibrary(db, file).tracks.get('t1')!;
+    expect(t.dateAdded?.getUTCFullYear()).toBe(2020);
+  });
+
+  it('nests playlists under their folder and lists their track ids', () => {
+    const lib = mapRowsToLibrary(db, file);
+    expect(lib.playlists).toHaveLength(1);
+    expect(lib.playlists[0]).toMatchObject({ name: 'Crates', type: 'FOLDER' });
+    expect(lib.playlists[0].children![0]).toMatchObject({
+      name: 'Gig', type: 'PLAYLIST', tracks: ['t1'],
+    });
+  });
+
+  it('uses the database path as the library path', () => {
+    expect(mapRowsToLibrary(db, file).libraryPath).toBe(file);
+  });
+});

--- a/tests/unit/safe-delete-paths.test.ts
+++ b/tests/unit/safe-delete-paths.test.ts
@@ -56,3 +56,24 @@ describe('computeDeletablePaths', () => {
     expect(computeDeletablePaths([composed, decomposed], [])).toHaveLength(1);
   });
 });
+
+describe('computeDeletablePaths — only ever regular files', () => {
+  // Rekordbox libraries really contain these: verified in a user's XML.
+  const isFile = (p: string) => p.endsWith('.mp3');
+
+  it('refuses a folder, which would take a whole album with it', () => {
+    expect(computeDeletablePaths(['/Music/Handbraekes/'], [], isFile)).toEqual([]);
+  });
+
+  it('refuses a streaming entry that has no file at all', () => {
+    expect(computeDeletablePaths(['/x/tidal:tracks:105015500'], [], isFile)).toEqual([]);
+  });
+
+  it('refuses a truncated location', () => {
+    expect(computeDeletablePaths(['/Music/Unknown Album/Pancake - Don&'], [], isFile)).toEqual([]);
+  });
+
+  it('still deletes a genuine duplicate file', () => {
+    expect(computeDeletablePaths(['/Music/dup.mp3'], [], isFile)).toEqual(['/Music/dup.mp3']);
+  });
+});

--- a/tests/unit/safe-delete-paths.test.ts
+++ b/tests/unit/safe-delete-paths.test.ts
@@ -40,4 +40,19 @@ describe('computeDeletablePaths', () => {
     );
     expect(result).toEqual(['/Music/real-loser.mp3']);
   });
+
+  it('never deletes a file whose path differs only in Unicode form', () => {
+    // macOS stores accents composed or decomposed and treats both as one file;
+    // rekordbox libraries contain both spellings for the same track.
+    const composed = '/Music/Bökken/WONTON.mp3';
+    const decomposed = '/Music/Bökken/WONTON.mp3';
+    expect(composed).not.toBe(decomposed);
+    expect(computeDeletablePaths([decomposed], [composed])).toEqual([]);
+  });
+
+  it('de-duplicates the same file written in both Unicode forms', () => {
+    const composed = '/Music/Bökken/WONTON.mp3';
+    const decomposed = '/Music/Bökken/WONTON.mp3';
+    expect(computeDeletablePaths([composed, decomposed], [])).toHaveLength(1);
+  });
 });

--- a/tests/unit/settings-strategy-persistence.test.ts
+++ b/tests/unit/settings-strategy-persistence.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+describe('resolution strategy persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    globalThis.localStorage.removeItem('rekordbox-settings');
+  });
+
+  it('writes the chosen strategy into localStorage', async () => {
+    const { useSettingsStore } = await import('../../src/renderer/stores/settingsStore');
+    useSettingsStore.getState().setResolutionStrategy('keep-preferred-path');
+    const raw = localStorage.getItem('rekordbox-settings');
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!).state.resolutionStrategy).toBe('keep-preferred-path');
+  });
+
+  it('restores the strategy when the store is rehydrated', async () => {
+    localStorage.setItem('rekordbox-settings', JSON.stringify({
+      state: { resolutionStrategy: 'keep-preferred-path' },
+      version: 1,
+    }));
+    const { useSettingsStore } = await import('../../src/renderer/stores/settingsStore');
+    await (useSettingsStore.persist as any)?.rehydrate?.();
+    expect(useSettingsStore.getState().resolutionStrategy).toBe('keep-preferred-path');
+  });
+});


### PR DESCRIPTION
## Read the rekordbox database directly

Loads a library from rekordbox's own encrypted `master.db`, no XML export needed. Verified against a real Rekordbox 7.2 database: 12,633 tracks, 57 playlists, ~210ms. Strictly read-only — the file is copied with its WAL and the copy is opened readonly, so rekordbox can stay open.

Three facts the code depends on, each found by testing rather than assumption:
- the driver defaults to chacha20, so `cipher='sqlcipher'` and `legacy=4` must precede the key or every read fails as "file is not a database";
- BPM is stored times 100;
- ordinary cues store `OutMsec = -1`, not null, so only a positive value marks a loop. A truthiness check reported 12,498 loops and zero cues.

The SQLCipher key is not shipped with the app; it is pasted once on the load screen.

## Never write over the database

Loading from the database set `libraryPath` to `master.db`, while resolve and relocate write XML to that path — which would have destroyed it. Every write path now refuses a `.db` path, and a banner marks a database-backed library read-only.

## Find your libraries

The load screen lists what is already on this machine — the rekordbox database plus XML exports in the folders people export to — newest first, with full paths. XML is checked for a `DJ_PLAYLISTS` root so unrelated files stay out.

## Backups

A Backups tab lists every backup, restores one (keeping the current state as a fresh backup first, so going back is never one-way), reveals or deletes it, and then asks whether to load the restored library. Reachable without a library loaded, which is when it is most needed.

## Broken entries

A real library held 214 entries that can never point at a file: 137 streaming tracks, 44 paths cut short by a bad import, 33 pointing at a folder. Maintenance lists them by reason and removes them from the library and any playlist listing them, after writing a backup.

**The dangerous part this uncovered**: the delete guard would have passed a folder straight to the trash, taking an album of music with it. Deletion now confirms each path is a regular file.

## Other fixes

- **Unicode paths**: macOS stores accents composed or decomposed and treats both as one file; rekordbox libraries hold both spellings. One file read as two, and the delete guard could have trashed the file the kept entry still points at. All path comparison normalises to NFC.
- **Cancel stayed hidden**: it lived in the empty results area, which disappears as soon as the first streamed set arrives. Progress and Cancel now sit in the toolbar for the whole scan.
- **Resolution strategy is remembered**: it went through the same debounce as typed fields and the unmount cleanup discarded pending writes.
- **Labels say what happens**: sets state `4 entries · 2 files`; each entry says whether it is an extra listing (no file removed) or has its own file. An in-app help section explains the difference.

## Test plan

- 296 unit tests green; `pnpm build` clean.
- Packaged build verified: the shipped native module decrypts a real master.db from `app.asar.unpacked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Load encrypted Rekordbox databases directly in read-only mode.
  * Discover available XML libraries and Rekordbox databases automatically.
  * View, restore, delete, and reveal library backups.
  * Detect and remove broken library entries from writable XML libraries.
  * Added duplicate-analysis help, clearer file/entry counts, and cancellable scans.
  * Remember database keys and resolution strategies between sessions.

* **Bug Fixes**
  * Improved Unicode and case-insensitive path matching.
  * Prevented deletion of folders, streaming entries, and invalid paths.
  * Added safer backup handling and database write protection.

* **Documentation**
  * Updated the README, changelog, and usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->